### PR TITLE
Update pkg-config project URL

### DIFF
--- a/maint/codes-net.pc.in
+++ b/maint/codes-net.pc.in
@@ -6,7 +6,7 @@ includedir=@includedir@
 Name: codes-net
 Description: Network functionality for CODES storage simulation
 Version: @PACKAGE_VERSION@
-URL: http://trac.mcs.anl.gov/projects/CODES
+URL: https://github.com/codes-org/codes
 Requires: codes-base
 Libs: -L${libdir} -lcodes-net
 Cflags: -I${includedir}

--- a/maint/codes.pc.in
+++ b/maint/codes.pc.in
@@ -23,7 +23,7 @@ swm_datarootdir=@SWM_DATAROOTDIR@
 Name: codes-base
 Description: Base functionality for CODES storage simulation
 Version: @PACKAGE_VERSION@
-URL: http://trac.mcs.anl.gov/projects/CODES
+URL: https://github.com/codes-org/codes
 Requires:
 Libs: -L${libdir} -lcodes ${ross_libs} ${argobots_libs} ${swm_libs} ${darshan_libs} ${dumpi_libs} ${cortex_libs}
 Cflags: -I${includedir} -I${swm_datarootdir} ${ross_cflags} ${darshan_cflags} ${swm_cflags} ${argobots_cflags} ${dumpi_cflags} ${cortex_cflags}


### PR DESCRIPTION
Updates the URL to CODES in the pkg-config files to point to the GitHub project. Current URL goes to a trac project that says permissions denied and broken image links in the top left corner.

