### PR TITLE
Injection pipeline fix: separate injection delay from propagation delay.

### DIFF
--- a/src/networks/model-net/dragonfly-dally.C
+++ b/src/networks/model-net/dragonfly-dally.C
@@ -3889,7 +3889,7 @@ static void router_packet_receive( router_state * s,
             bf->c3 = 1;
             terminal_dally_message *m;
             msg->num_cll++;
-            ts = codes_local_latency(lp); 
+            ts = maxd(s->next_output_available_time[output_port], tw_now(lp)) - tw_now(lp);
             tw_event *e = model_net_method_event_new(lp->gid, ts, lp,
                     DRAGONFLY_DALLY_ROUTER, (void**)&m, NULL);
             m->type = R_SEND;
@@ -4281,7 +4281,7 @@ static void router_buf_update(router_state * s, tw_bf * bf, terminal_dally_messa
         bf->c2 = 1;
         terminal_dally_message *m;
         msg->num_cll++;
-        tw_stime ts = codes_local_latency(lp);
+        tw_stime ts = maxd(s->next_output_available_time[indx], tw_now(lp)) - tw_now(lp);
         tw_event *e = model_net_method_event_new(lp->gid, ts, lp, DRAGONFLY_DALLY_ROUTER,
                 (void**)&m, NULL);
         m->type = R_SEND;

--- a/src/networks/model-net/dragonfly-dally.C
+++ b/src/networks/model-net/dragonfly-dally.C
@@ -1926,9 +1926,9 @@ void issue_bw_monitor_event(terminal_state * s, tw_bf * bf, terminal_dally_messa
     if(tw_now(lp) > max_qos_monitor)
         return;
     
-    msg->num_cll++;
+    //msg->num_cll++;
     terminal_dally_message * m; 
-    tw_stime bw_ts = bw_reset_window + codes_local_latency(lp);
+    tw_stime bw_ts = bw_reset_window;
     tw_event * e = model_net_method_event_new(lp->gid, bw_ts, lp, DRAGONFLY_DALLY,
             (void**)&m, NULL); 
     m->type = T_BANDWIDTH;
@@ -2020,8 +2020,8 @@ void issue_rtr_bw_monitor_event(router_state *s, tw_bf *bf, terminal_dally_messa
     if(tw_now(lp) > max_qos_monitor)
         return;
     
-    msg->num_cll++;
-    tw_stime bw_ts = bw_reset_window + codes_local_latency(lp);
+    //msg->num_cll++;
+    tw_stime bw_ts = bw_reset_window;
     terminal_dally_message *m;
     tw_event * e = model_net_method_event_new(lp->gid, bw_ts, lp,
             DRAGONFLY_DALLY_ROUTER, (void**)&m, NULL);
@@ -2577,8 +2577,8 @@ static void packet_generate(terminal_state * s, tw_bf * bf, terminal_dally_messa
         {
             bf->c1 = 1;
             /* Issue an event on both terminal and router to monitor bandwidth */
-            msg->num_cll++;
-            tw_stime bw_ts = bw_reset_window + codes_local_latency(lp);
+            //msg->num_cll++;
+            tw_stime bw_ts = bw_reset_window;
             terminal_dally_message * m;
             tw_event * e = model_net_method_event_new(lp->gid, bw_ts, lp, DRAGONFLY_DALLY,
                 (void**)&m, NULL);
@@ -2668,8 +2668,8 @@ static void packet_generate(terminal_state * s, tw_bf * bf, terminal_dally_messa
     }
 
     injection_ts = bytes_to_ns(msg->packet_size, s->params->cn_bandwidth);
-    msg->num_rngs++;
-    nic_ts = g_tw_lookahead + injection_ts + tw_rand_unif(lp->rng);
+    //msg->num_rngs++;
+    nic_ts = g_tw_lookahead + injection_ts;
 
     if(s->terminal_length[vcg] < s->params->cn_vc_size) {
         model_net_method_idle_event(nic_ts, 0, lp);
@@ -2690,8 +2690,8 @@ static void packet_generate(terminal_state * s, tw_bf * bf, terminal_dally_messa
     
     if(s->in_send_loop == 0) {
         bf->c5 = 1;
-        msg->num_cll++;
-        ts = codes_local_latency(lp);
+        //msg->num_cll++;
+        ts = 0;
         terminal_dally_message *m;
         tw_event* e = model_net_method_event_new(lp->gid, ts, lp, DRAGONFLY_DALLY, 
         (void**)&m, NULL);
@@ -2837,8 +2837,8 @@ static void packet_send(terminal_state * s, tw_bf * bf, terminal_dally_message *
 
     s->qos_data[vcg] += data_size;
   
-    msg->num_rngs++;
-    injection_delay += g_tw_lookahead + tw_rand_unif(lp->rng);
+    //msg->num_rngs++;
+    injection_delay += g_tw_lookahead;
     
     msg->saved_available_time = s->terminal_available_time;
     s->terminal_available_time = maxd(s->terminal_available_time, tw_now(lp));
@@ -2883,8 +2883,8 @@ static void packet_send(terminal_state * s, tw_bf * bf, terminal_dally_message *
 
     if(cur_entry->msg.chunk_id == num_chunks - 1 && (cur_entry->msg.local_event_size_bytes > 0)) 
     {
-        msg->num_cll++;
-        tw_stime local_ts = codes_local_latency(lp); 
+        //msg->num_cll++;
+        tw_stime local_ts = 0;
         tw_event *e_new = tw_event_new(cur_entry->msg.sender_lp, local_ts, lp);
         void * m_new = tw_event_data(e_new);
         void *local_event = (char*)cur_entry->event_data + 
@@ -2911,8 +2911,8 @@ static void packet_send(terminal_state * s, tw_bf * bf, terminal_dally_message *
     /* if there is another packet inline then schedule another send event */
     if(cur_entry != NULL && s->vc_occupancy[next_vcg] + s->params->chunk_size <= s->params->cn_vc_size) {
         terminal_dally_message *m_new;
-        msg->num_rngs++;
-        injection_ts += tw_rand_unif(lp->rng);
+        //msg->num_rngs++;
+        //injection_ts += tw_rand_unif(lp->rng);
         e = model_net_method_event_new(lp->gid, injection_ts, lp, DRAGONFLY_DALLY, (void**)&m_new, NULL);
         m_new->type = T_SEND;
         m_new->magic = terminal_magic_num;
@@ -2925,8 +2925,8 @@ static void packet_send(terminal_state * s, tw_bf * bf, terminal_dally_message *
     if(s->issueIdle) {
         bf->c5 = 1;
         s->issueIdle = 0;
-        msg->num_rngs++;
-        injection_ts += tw_rand_unif(lp->rng);
+        //msg->num_rngs++;
+        //injection_ts += tw_rand_unif(lp->rng);
         model_net_method_idle_event(injection_ts, 0, lp);
     
         if(s->last_buf_full > 0.0)
@@ -2952,8 +2952,8 @@ static void send_remote_event(terminal_state * s, terminal_dally_message * msg, 
 {
     void * tmp_ptr = model_net_method_get_edata(DRAGONFLY_DALLY, msg);
     
-    msg->num_rngs++;
-    tw_stime ts = g_tw_lookahead + mpi_soft_overhead + tw_rand_unif(lp->rng);
+    //msg->num_rngs++;
+    tw_stime ts = g_tw_lookahead + mpi_soft_overhead;
 
     if (msg->is_pull){
         bf->c4 = 1;
@@ -3131,8 +3131,8 @@ static void packet_arrive(terminal_state * s, tw_bf * bf, terminal_dally_message
     if(msg->packet_ID == LLU(TRACK_PKT) && msg->src_terminal_id == T_ID)
         printf("\n Packet %llu arrived at lp %llu hops %d ", LLU(msg->sender_lp), LLU(lp->gid), msg->my_N_hop);
     
-    msg->num_rngs++;
-    tw_stime ts = g_tw_lookahead + s->params->cn_credit_delay + tw_rand_unif(lp->rng);
+    //msg->num_rngs++;
+    tw_stime ts = g_tw_lookahead + s->params->cn_credit_delay;
 
     // no method_event here - message going to router
     tw_event * buf_e;
@@ -3339,8 +3339,8 @@ static void terminal_buf_update(terminal_state * s,
     if(num_qos_levels > 1)
         vcg = get_vcg_from_category(msg);
 
-    msg->num_cll++;
-    tw_stime ts = codes_local_latency(lp);
+    //msg->num_cll++;
+    tw_stime ts = 0;
     s->vc_occupancy[vcg] -= s->params->chunk_size;
     
     if(s->in_send_loop == 0 && s->terminal_msgs[vcg] != NULL) {
@@ -3688,8 +3688,8 @@ static void router_credit_send(router_state * s, terminal_dally_message * msg,
      * the injection delay, and propagation delay of the channel. But this level of 
      * granularity _may_ only be necessary for specific credit-based flow control 
      * studies. It should certainly be considered for those. */
-    (*rng_counter)++;
-    ts = g_tw_lookahead + credit_delay +  tw_rand_unif(lp->rng);
+    //(*rng_counter)++;
+    ts = g_tw_lookahead + credit_delay;
 
     if (is_terminal) {
         buf_e = model_net_method_event_new(dest, ts, lp, DRAGONFLY_DALLY, 
@@ -3775,8 +3775,8 @@ static void router_packet_receive( router_state * s,
         if(s->is_monitoring_bw == 0)
         {
             bf->c1 = 1;
-            msg->num_cll++;
-            tw_stime bw_ts = bw_reset_window + codes_local_latency(lp);
+            //msg->num_cll++;
+            tw_stime bw_ts = bw_reset_window;
             terminal_dally_message * m;
             tw_event * e = model_net_method_event_new(lp->gid, bw_ts, lp, 
                 DRAGONFLY_DALLY_ROUTER, (void**)&m, NULL); 

--- a/src/networks/model-net/dragonfly-dally.C
+++ b/src/networks/model-net/dragonfly-dally.C
@@ -4102,7 +4102,7 @@ static void router_packet_send( router_state * s, tw_bf * bf, terminal_dally_mes
     msg->num_rngs++;
     injection_delay += g_tw_lookahead + tw_rand_unif(lp->rng) + s->params->router_delay;
     msg->num_rngs++;
-    propagation_delay += g_tw_lookahead + tw_rand_unif(lp->rng) + s->params->router_delay;
+    propagation_delay += g_tw_lookahead + tw_rand_unif(lp->rng);
 
     msg->saved_available_time = s->next_output_available_time[output_port];
     s->next_output_available_time[output_port] = 

--- a/src/networks/model-net/dragonfly-dally.C
+++ b/src/networks/model-net/dragonfly-dally.C
@@ -4096,8 +4096,7 @@ static void router_packet_send( router_state * s, tw_bf * bf, terminal_dally_mes
     if((cur_entry->msg.packet_size < s->params->chunk_size) && (cur_entry->msg.chunk_id == num_chunks - 1))
         injection_delay = bytes_to_ns(cur_entry->msg.packet_size % s->params->chunk_size, bandwidth);
 
-    msg->num_rngs++;
-    injection_delay += g_tw_lookahead + tw_rand_unif(lp->rng) + s->params->router_delay;
+    injection_delay += s->params->router_delay;
 
     msg->saved_available_time = s->next_output_available_time[output_port];
     s->next_output_available_time[output_port] = 
@@ -4187,8 +4186,6 @@ static void router_packet_send( router_state * s, tw_bf * bf, terminal_dally_mes
     assert(cur_entry != NULL); 
 
     terminal_dally_message *m_new;
-    msg->num_rngs++;
-    injection_ts += g_tw_lookahead + tw_rand_unif(lp->rng);
     e = model_net_method_event_new(lp->gid, injection_ts, lp, DRAGONFLY_DALLY_ROUTER,
                 (void**)&m_new, NULL);
     m_new->type = R_SEND;

--- a/src/networks/model-net/dragonfly-dally.C
+++ b/src/networks/model-net/dragonfly-dally.C
@@ -1996,7 +1996,7 @@ void issue_rtr_bw_monitor_event(router_state *s, tw_bf *bf, terminal_dally_messa
             #if DEBUG_QOS == 1 
             if(dragonfly_rtr_bw_log != NULL)
             {
-                if(s->qos_data[i][j] > 0)
+                if(s->qos_data[j][k] > 0)
                 {
                     fprintf(dragonfly_rtr_bw_log, "\n %d %f %d %d %d %d %d %f", s->router_id, tw_now(lp), i, j, bw_consumed, s->qos_status[i][j], s->qos_data[i][j], s->busy_time_sample[i]);
                 }
@@ -3889,7 +3889,7 @@ static void router_packet_receive( router_state * s,
             bf->c3 = 1;
             terminal_dally_message *m;
             msg->num_cll++;
-            ts = maxd(s->next_output_available_time[output_chan], tw_now(lp)) - tw_now(lp);
+            ts = codes_local_latency(lp); 
             tw_event *e = model_net_method_event_new(lp->gid, ts, lp,
                     DRAGONFLY_DALLY_ROUTER, (void**)&m, NULL);
             m->type = R_SEND;
@@ -4079,7 +4079,7 @@ static void router_packet_send( router_state * s, tw_bf * bf, terminal_dally_mes
     if(cur_entry->msg.packet_size < s->params->chunk_size)
         num_chunks++;
 
-    /* Injection (or transmission) delay: Time taken for the data to be placed on the link/channel
+    /* Injection delay: Time taken for the data to be placed on the link/channel
      *  - Based on bandwidth
      * Propagtion delay: Time taken for the data to cross the link and arrive at the reciever
      *  - A physical property of the material of teh link (eg. copper, optical fiber)
@@ -4281,7 +4281,7 @@ static void router_buf_update(router_state * s, tw_bf * bf, terminal_dally_messa
         bf->c2 = 1;
         terminal_dally_message *m;
         msg->num_cll++;
-        tw_stime ts = maxd(s->next_output_available_time[indx], tw_now(lp)) - tw_now(lp);
+        tw_stime ts = codes_local_latency(lp);
         tw_event *e = model_net_method_event_new(lp->gid, ts, lp, DRAGONFLY_DALLY_ROUTER,
                 (void**)&m, NULL);
         m->type = R_SEND;

--- a/src/networks/model-net/dragonfly-dally.C
+++ b/src/networks/model-net/dragonfly-dally.C
@@ -1996,7 +1996,7 @@ void issue_rtr_bw_monitor_event(router_state *s, tw_bf *bf, terminal_dally_messa
             #if DEBUG_QOS == 1 
             if(dragonfly_rtr_bw_log != NULL)
             {
-                if(s->qos_data[j][k] > 0)
+                if(s->qos_data[i][j] > 0)
                 {
                     fprintf(dragonfly_rtr_bw_log, "\n %d %f %d %d %d %d %d %f", s->router_id, tw_now(lp), i, j, bw_consumed, s->qos_status[i][j], s->qos_data[i][j], s->busy_time_sample[i]);
                 }
@@ -3889,7 +3889,7 @@ static void router_packet_receive( router_state * s,
             bf->c3 = 1;
             terminal_dally_message *m;
             msg->num_cll++;
-            ts = codes_local_latency(lp); 
+            ts = maxd(s->next_output_available_time[output_chan], tw_now(lp)) - tw_now(lp);
             tw_event *e = model_net_method_event_new(lp->gid, ts, lp,
                     DRAGONFLY_DALLY_ROUTER, (void**)&m, NULL);
             m->type = R_SEND;
@@ -4079,7 +4079,7 @@ static void router_packet_send( router_state * s, tw_bf * bf, terminal_dally_mes
     if(cur_entry->msg.packet_size < s->params->chunk_size)
         num_chunks++;
 
-    /* Injection delay: Time taken for the data to be placed on the link/channel
+    /* Injection (or transmission) delay: Time taken for the data to be placed on the link/channel
      *  - Based on bandwidth
      * Propagtion delay: Time taken for the data to cross the link and arrive at the reciever
      *  - A physical property of the material of teh link (eg. copper, optical fiber)
@@ -4281,7 +4281,7 @@ static void router_buf_update(router_state * s, tw_bf * bf, terminal_dally_messa
         bf->c2 = 1;
         terminal_dally_message *m;
         msg->num_cll++;
-        tw_stime ts = codes_local_latency(lp);
+        tw_stime ts = maxd(s->next_output_available_time[indx], tw_now(lp)) - tw_now(lp);
         tw_event *e = model_net_method_event_new(lp->gid, ts, lp, DRAGONFLY_DALLY_ROUTER,
                 (void**)&m, NULL);
         m->type = R_SEND;


### PR DESCRIPTION
This should allow multiple flits within the same packet to be pipelined on a link. The injection delay (via the bandwidth) is used to calc the sender's next_available_time after the flit in injected and using the channel delay is used to calc when the flit arrives at next hop. Therefore, a second flit can be injected into the link while the first flit is still in transit on the link.