### PR TITLE
SWM Configuration runtime passing

### DIFF
--- a/src/network-workloads/model-net-mpi-replay.c
+++ b/src/network-workloads/model-net-mpi-replay.c
@@ -2157,8 +2157,27 @@ void nw_test_init(nw_state* s, tw_lp* lp)
        }
        else if(strlen(workloads_conf_file) > 0)
        {
-            strcpy(oc_params.workload_name, file_name_of_job[lid.job]);
-       
+            short filename_supplied = 0;
+            int len = strlen(file_name_of_job[lid.job]);
+            if (len > 4) {
+                char *last_five = &file_name_of_job[lid.job][len-5];
+                if (strcmp(".json", last_five) == 0)
+                {
+                    filename_supplied = 1;
+                }
+            }
+            if (filename_supplied) { //then we were supplied a filepath
+                strcpy(oc_params.file_path, file_name_of_job[lid.job]);
+                oc_params.workload_name[0] = '\0';
+                if(lid.rank == 0)
+                    printf("Workload Filepath provided: %s\n", oc_params.file_path);
+            }
+            else { //then we were supplied just the name of the workload and will use on of the defaults
+                strcpy(oc_params.workload_name, file_name_of_job[lid.job]);
+                oc_params.file_path[0] = '\0';
+                if(lid.rank == 0)
+                    printf("Workload name provided: %s\n",oc_params.workload_name);
+            }
        }
 
        //assert(strcmp(oc_params.workload_name, "lammps") == 0 || strcmp(oc_params.workload_name, "nekbone") == 0);

--- a/src/workload/methods/codes-online-comm-wrkld.C
+++ b/src/workload/methods/codes-online-comm-wrkld.C
@@ -854,8 +854,10 @@ static int comm_online_workload_load(const char * params, int app_id, int rank)
         boost::property_tree::json_parser::read_json(jsonFile, root);
         uint32_t process_cnt = root.get<uint32_t>("jobs.size", 1);
         cpu_freq = root.get<double>("jobs.cfg.cpu_freq") / 1e9;
-        if (o_params->workload_name[0] == '\0') //if we instead had a configuration filename supplied, get worklaod name from jobs.cfg.app
+        if (o_params->workload_name[0] == '\0') { //if we instead had a configuration filename supplied, get worklaod name from jobs.cfg.app
             strcpy(o_params->workload_name, root.get<string>("jobs.cfg.app").c_str());
+            strcpy(my_ctx->sctx.workload_name, o_params->workload_name);
+        }
     }
     catch(std::exception & e)
     {


### PR DESCRIPTION
These commits allow for SWM configurations to be passed in the workload configuration file so that different SWM workload configurations can be specified at _runtime_ instead of needing to recompile SWM+CODES for minor configuration changes.

Note: This obviously affects parsing of the workload configuration file -- changing how workload config files are interpreted and used so this should be reserved for merging until we are at the threshold of CODES 2.0