### PR TITLE
Hotfix multi def

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.67])
-AC_INIT([codes], [1.4.1], [http://trac.mcs.anl.gov/projects/codes/newticket],[],[http://www.mcs.anl.gov/projects/codes/])
+AC_INIT([codes], [1.4.2], [http://trac.mcs.anl.gov/projects/codes/newticket],[],[http://www.mcs.anl.gov/projects/codes/])
 LT_INIT
 
 AC_CANONICAL_TARGET

--- a/src/network-workloads/model-net-mpi-replay.c
+++ b/src/network-workloads/model-net-mpi-replay.c
@@ -107,9 +107,9 @@ tw_stime soft_delay_mpi = 2500;
 tw_stime nic_delay = 1000;
 tw_stime copy_per_byte_eager = 0.55;
 
-struct codes_jobmap_ctx *jobmap_ctx;
-struct codes_jobmap_params_list jobmap_p;
-struct codes_jobmap_params_identity jobmap_ident_p; // for if an alloc file isn't supplied.
+static struct codes_jobmap_ctx *jobmap_ctx;
+static struct codes_jobmap_params_list jobmap_p;
+static struct codes_jobmap_params_identity jobmap_ident_p; // for if an alloc file isn't supplied.
 
 
 /* Variables for Cortex Support */

--- a/src/network-workloads/model-net-synthetic-slimfly.c
+++ b/src/network-workloads/model-net-synthetic-slimfly.c
@@ -69,9 +69,9 @@ void init_worst_case_mapping();
 /* Global variables for worst-case workload pairing */
 static int num_local_channels;
 static int num_global_channels;
-int *X;
-int *X_prime;
-int X_size;
+static int *X;
+static int *X_prime;
+static int X_size;
 
 /* type of events */
 enum svr_event


### PR DESCRIPTION
Fixes a lack of usage of the keyword static on a few file-local globals that prevented building with gcc > 10.