### PR TITLE
Tiny fix that shows up only when running an experiment with the `-O3` compilation flag

### DIFF
--- a/codes/codes-workload.h
+++ b/codes/codes-workload.h
@@ -302,7 +302,7 @@ void codes_workload_free_config_return(codes_workload_config_return *c);
  */
 int codes_workload_load(
         const char* type,
-        const char* params,
+        const void* params,
         int app_id,
         int rank);
 
@@ -361,7 +361,7 @@ struct codes_workload_method
     void * (*codes_workload_read_config) (
             ConfigHandle *handle, char const * section_name,
             char const * annotation, int num_ranks);
-    int (*codes_workload_load)(const char* params, int app_id, int rank);
+    int (*codes_workload_load)(const void* params, int app_id, int rank);
     void (*codes_workload_get_next)(int app_id, int rank, struct codes_workload_op *op);
     void (*codes_workload_get_next_rc2)(int app_id, int rank);
     int (*codes_workload_get_rank_cnt)(const char* params, int app_id);

--- a/src/network-workloads/model-net-mpi-replay.c
+++ b/src/network-workloads/model-net-mpi-replay.c
@@ -76,7 +76,7 @@ static tw_stime mean_interval = 100000;
 static int payload_sz = 1024;
 
 /* Doing LP IO*/
-static char * params = NULL;
+static void * params = NULL;
 static char lp_io_dir[256] = {'\0'};
 static char sampling_dir[32] = {'\0'};
 static char mpi_msg_dir[32] = {'\0'};
@@ -2327,6 +2327,8 @@ void nw_test_init(nw_state* s, tw_lp* lp)
    assert(num_net_traces <= num_mpi_lps);
 
    struct codes_jobmap_id lid;
+   online_comm_params oc_params;
+   dumpi_trace_params params_d;
 
    if(alloc_spec)
    {
@@ -2356,14 +2358,10 @@ void nw_test_init(nw_state* s, tw_lp* lp)
    s->known_completed_jobs = calloc(num_jobs, sizeof(int));
 
    if (strcmp(workload_type, "dumpi") == 0){
-       dumpi_trace_params params_d;
        strcpy(params_d.file_name, file_name_of_job[lid.job]);
        params_d.num_net_traces = num_traces_of_job[lid.job];
-       params_d.nprocs = nprocs; 
-       params = (char*)&params_d;
-       strcpy(params_d.file_name, file_name_of_job[lid.job]);
-       params_d.num_net_traces = num_traces_of_job[lid.job];
-       params = (char*)&params_d;
+       params_d.nprocs = nprocs;
+       params = (void*)&params_d;
        strcpy(type_name, "dumpi-trace-workload");
 
        if(strlen(workloads_conf_file) > 0)
@@ -2379,9 +2377,6 @@ void nw_test_init(nw_state* s, tw_lp* lp)
 #endif
    }
    else if(strcmp(workload_type, "online") == 0){
-           
-       online_comm_params oc_params;
-       
        if(strlen(workload_name) > 0)
        {
            strcpy(oc_params.workload_name, workload_name); 
@@ -2417,7 +2412,7 @@ void nw_test_init(nw_state* s, tw_lp* lp)
        /*TODO: nprocs is different for dumpi and online workload. for
         * online, it is the number of ranks to be simulated. */
        oc_params.nprocs = num_traces_of_job[lid.job]; 
-       params = (char*)&oc_params;
+       params = (void*)&oc_params;
        strcpy(type_name, "online_comm_workload");
    }
 

--- a/src/workload/codes-workload.c
+++ b/src/workload/codes-workload.c
@@ -166,7 +166,7 @@ void codes_workload_free_config_return(codes_workload_config_return *c)
 
 int codes_workload_load(
         const char* type,
-        const char* params,
+        const void* params,
         int app_id,
         int rank)
 {

--- a/src/workload/methods/codes-checkpoint-wrkld.c
+++ b/src/workload/methods/codes-checkpoint-wrkld.c
@@ -31,7 +31,7 @@ static void * checkpoint_workload_read_config(
         char const * section_name,
         char const * annotation,
         int num_ranks);
-static int checkpoint_workload_load(const char* params, int app_id, int rank);
+static int checkpoint_workload_load(const void* params, int app_id, int rank);
 static void checkpoint_workload_get_next(int app_id, int rank, struct codes_workload_op *op);
 static void checkpoint_workload_get_next_rc2(int app_id, int rank);
 
@@ -112,7 +112,7 @@ static void * checkpoint_workload_read_config(
     return p;
 }
 
-static int checkpoint_workload_load(const char* params, int app_id, int rank)
+static int checkpoint_workload_load(const void* params, int app_id, int rank)
 {
     checkpoint_wrkld_params *c_params = (checkpoint_wrkld_params *)params;
     struct checkpoint_state* new_state;

--- a/src/workload/methods/codes-darshan3-io-wrkld.c
+++ b/src/workload/methods/codes-darshan3-io-wrkld.c
@@ -53,7 +53,7 @@ static void * darshan_io_workload_read_config(
         char const * annotation,
         int num_ranks);
 /* Darshan workload generator's implementation of the CODES workload API */
-static int darshan_psx_io_workload_load(const char *params, int app_id, int rank);
+static int darshan_psx_io_workload_load(const void *params, int app_id, int rank);
 static void darshan_psx_io_workload_get_next(int app_id, int rank, struct codes_workload_op *op);
 static int darshan_psx_io_workload_get_rank_cnt(const char *params, int app_id);
 static int darshan_rank_hash_compare(void *key, struct qhash_head *link);
@@ -179,7 +179,7 @@ static int darshan_psx_io_workload_get_time(const char *params, int app_id, int 
 }
 
 /* load the workload generator for this rank, given input params */
-static int darshan_psx_io_workload_load(const char *params, int app_id, int rank)
+static int darshan_psx_io_workload_load(const void *params, int app_id, int rank)
 {
     darshan_params *d_params = (darshan_params *)params;
     darshan_fd logfile_fd = NULL;

--- a/src/workload/methods/codes-dumpi-trace-nw-wrkld.c
+++ b/src/workload/methods/codes-dumpi-trace-nw-wrkld.c
@@ -119,7 +119,7 @@ static inline double time_to_ns_lf(dumpi_clock t){
 }*/
 
 /* load the trace */
-static int dumpi_trace_nw_workload_load(const char* params, int app_id, int rank);
+static int dumpi_trace_nw_workload_load(const void* params, int app_id, int rank);
 
 /* dumpi implementation of get next operation in the workload */
 static void dumpi_trace_nw_workload_get_next(int app_id, int rank, struct codes_workload_op *op);
@@ -770,7 +770,7 @@ static int hash_rank_compare(void *key, struct qhash_head *link)
     return 0;
 }
 
-int dumpi_trace_nw_workload_load(const char* params, int app_id, int rank)
+int dumpi_trace_nw_workload_load(const void* params, int app_id, int rank)
 {
 	libundumpi_callbacks callbacks;
 	libundumpi_cbpair callarr[DUMPI_END_OF_STREAM];

--- a/src/workload/methods/codes-iolang-wrkld.c
+++ b/src/workload/methods/codes-iolang-wrkld.c
@@ -27,7 +27,7 @@ static void * iolang_io_workload_read_config(
         int num_ranks);
 
 /* load the workload file */
-static int iolang_io_workload_load(const char* params, int app_id, int rank);
+static int iolang_io_workload_load(const void* params, int app_id, int rank);
 
 /* get next operation */
 static void iolang_io_workload_get_next(int app_id, int rank, struct codes_workload_op *op);
@@ -87,7 +87,7 @@ static void * iolang_io_workload_read_config(
 }
 
 /* loads the workload file for each simulated MPI rank/ compute node LP */
-int iolang_io_workload_load(const char* params, int app_id, int rank)
+int iolang_io_workload_load(const void* params, int app_id, int rank)
 {
     int t = -1;
     iolang_params* i_param = (struct iolang_params*)params;

--- a/src/workload/methods/codes-iomock-wrkld.c
+++ b/src/workload/methods/codes-iomock-wrkld.c
@@ -132,7 +132,7 @@ static void * iomock_workload_read_config(
 }
 
 /* load the workload file */
-static int iomock_workload_load(const char* params, int app_id, int rank)
+static int iomock_workload_load(const void* params, int app_id, int rank)
 {
     iomock_params const * p = (iomock_params const *) params;
 

--- a/src/workload/methods/codes-online-comm-wrkld.C
+++ b/src/workload/methods/codes-online-comm-wrkld.C
@@ -933,7 +933,7 @@ string get_default_path(online_comm_params * o_params)
 }
 
 
-static int comm_online_workload_load(const char * params, int app_id, int rank)
+static int comm_online_workload_load(const void * params, int app_id, int rank)
 {
     /* LOAD parameters from JSON file*/
     online_comm_params * o_params = (online_comm_params*)params;

--- a/src/workload/methods/codes-recorder-io-wrkld.c
+++ b/src/workload/methods/codes-recorder-io-wrkld.c
@@ -53,7 +53,7 @@ struct rank_traces_context
 };
 
 /* CODES workload API functions for workloads generated from recorder traces*/
-static int recorder_io_workload_load(const char *params, int app_id, int rank);
+static int recorder_io_workload_load(const void *params, int app_id, int rank);
 static void recorder_io_workload_get_next(int app_id, int rank, struct codes_workload_op *op);
 
 /* helper functions for recorder workload CODES API */
@@ -73,7 +73,7 @@ static struct qhash_table *rank_tbl = NULL;
 static int rank_tbl_pop = 0;
 
 /* load the workload generator for this rank, given input params */
-static int recorder_io_workload_load(const char *params, int app_id, int rank)
+static int recorder_io_workload_load(const void *params, int app_id, int rank)
 {
     recorder_params *r_params = (recorder_params *) params;
     struct rank_traces_context *newv = NULL;

--- a/src/workload/methods/test-workload-method.c
+++ b/src/workload/methods/test-workload-method.c
@@ -14,7 +14,7 @@
 #include "ross.h"
 #include "codes/codes-workload.h"
 
-static int test_workload_load(const char* params, int app_id, int rank);
+static int test_workload_load(const void* params, int app_id, int rank);
 static void test_workload_get_next(int app_id, int rank, struct codes_workload_op *op);
 
 /* state information for each rank that is retrieving requests */
@@ -38,7 +38,7 @@ struct codes_workload_method test_workload_method =
     .codes_workload_get_next = test_workload_get_next,
 };
 
-static int test_workload_load(const char* params, int app_id, int rank)
+static int test_workload_load(const void* params, int app_id, int rank)
 {
     /* no params in this case; this example will work with any number of
      * ranks


### PR DESCRIPTION
This tiny fix should be merged into "master". It does not alter the behavior of CODES. It is a fix to a bug that appeared.

The bug in question is:

## Improper use of variable declaration inside a scope provokes segfault on optimized code `-O3`

A variable was declared and defined under a scope that was disregarded. Later on, outside of the scope a reference to the variable was used again causing a segfault.

This expression was never executed (optimized out):

> oc_params.nprocs = num_traces_of_job[lid.job];

because `oc_params.nprocs` was never used within the scope of `oc_params`.

Later on, a pointer to `oc_params` tries to access `nprocs` but this contains only garbage, and this triggers a segfault down the line.