### PR TITLE
Some assorted build fixes

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -62,7 +62,6 @@ list(APPEND SRCS
     surrogate/app-iteration-predictor/average.c
     surrogate/packet-latency-predictor/common.c
     surrogate/packet-latency-predictor/average.c
-    surrogate/director-client.C
 
     iokernellang/codesparser.h
     iokernellang/codesparser.c
@@ -125,6 +124,23 @@ if(USE_TORCH)
     list(APPEND LIBS_TO_LINK ${TORCH_LIBRARIES})
 endif()
 
+# ZMQML / director-client (opt-in). When USE_ZMQML=ON, callers must
+# point ZMQML_BUILD_PATH at a directory containing libzmqmlrequester.so
+# (build it via src/surrogate/zmqml/Makefile, or set ZMQML_BUILD_PATH to
+# wherever you installed it). When OFF (the default), CODES builds with
+# no surrogate/director-client linkage; configs that reference
+# "dir-nw-lp" will fail at runtime because the LP type isn't registered.
+option(USE_ZMQML "Build the director-client + zmqml surrogate integration" OFF)
+if(USE_ZMQML)
+    if(NOT ZMQML_BUILD_PATH)
+        message(FATAL_ERROR
+            "USE_ZMQML=ON but ZMQML_BUILD_PATH is unset.\n"
+            "Build src/surrogate/zmqml/libzmqmlrequester.so first, then "
+            "reconfigure with -DZMQML_BUILD_PATH=<dir containing the .so>.")
+    endif()
+    list(APPEND SRCS surrogate/director-client.C)
+endif()
+
 add_library(codes STATIC ${SRCS})
 
 list(APPEND LIBS_TO_LINK ${MPI_C_LIBRARIES})
@@ -159,11 +175,13 @@ if(USE_ONLINE)
     endif()
 endif()
 
-# ZMQML
-add_library(zmqmlrequester SHARED IMPORTED GLOBAL)
-set_target_properties(zmqmlrequester PROPERTIES 
-    IMPORTED_LOCATION "${ZMQML_BUILD_PATH}/libzmqmlrequester.so"
-    INTERFACE_INCLUDE_DIRECTORIES "${ZMQML_BUILD_PATH}")
+if(USE_ZMQML)
+    add_library(zmqmlrequester SHARED IMPORTED GLOBAL)
+    set_target_properties(zmqmlrequester PROPERTIES
+        IMPORTED_LOCATION "${ZMQML_BUILD_PATH}/libzmqmlrequester.so"
+        INTERFACE_INCLUDE_DIRECTORIES "${ZMQML_BUILD_PATH}")
+    target_compile_definitions(codes PUBLIC USE_ZMQML)
+endif()
 
 #LINK ROSS
 # target_link_libraries(codes PUBLIC #{pkgcfg_lib_ROSS_ROSS})
@@ -176,7 +194,7 @@ target_include_directories(codes PUBLIC
     ${PROJECT_SOURCE_DIR}/codes
     ${PROJECT_SOURCE_DIR}/src
     ${PROJECT_SOURCE_DIR}/src/modelconfig
-    $<TARGET_PROPERTY:zmqmlrequester,INTERFACE_INCLUDE_DIRECTORIES>
+    $<$<BOOL:${USE_ZMQML}>:$<TARGET_PROPERTY:zmqmlrequester,INTERFACE_INCLUDE_DIRECTORIES>>
 )
 
 target_link_libraries(codes PUBLIC ${LIBS_TO_LINK})
@@ -209,14 +227,20 @@ if(USE_DUMPI)
     list(APPEND CODES_TARGETS model-net-dumpi-traces-dump)
 endif()
 
-# ZMQ
-pkg_check_modules(PC_ZeroMQ QUIET zmq)
-find_path(ZeroMQ_INCLUDE_DIR NAMES zmq.hpp PATHS ${PC_ZeroMQ_INCLUDE_DIRS})
-find_library(ZeroMQ_LIBRARY NAMES zmq PATHS ${PC_ZeroMQ_LIBRARY_DIRS})
+# ZMQ — only resolved + linked when USE_ZMQML is on; otherwise nothing
+# in the codes library calls into libzmq.
+if(USE_ZMQML)
+    pkg_check_modules(PC_ZeroMQ QUIET zmq)
+    find_path(ZeroMQ_INCLUDE_DIR NAMES zmq.hpp PATHS ${PC_ZeroMQ_INCLUDE_DIRS})
+    find_library(ZeroMQ_LIBRARY NAMES zmq PATHS ${PC_ZeroMQ_LIBRARY_DIRS})
+endif()
 
 foreach(tar IN LISTS CODES_TARGETS)
     target_include_directories(${tar} PUBLIC ${CODES_INCLUDE_DIRS} ${ROSS_INCLUDE_DIRS})
-    target_link_libraries(${tar} PUBLIC codes ${LIBS_TO_LINK} zmqmlrequester ${ZeroMQ_LIBRARY})
+    target_link_libraries(${tar} PUBLIC codes ${LIBS_TO_LINK})
+    if(USE_ZMQML)
+        target_link_libraries(${tar} PUBLIC zmqmlrequester ${ZeroMQ_LIBRARY})
+    endif()
 endforeach()
 
 

--- a/src/network-workloads/model-net-mpi-replay.c
+++ b/src/network-workloads/model-net-mpi-replay.c
@@ -3564,7 +3564,7 @@ static void make_qlist_cpy(struct qlist_head * into, struct qlist_head const * f
         qlist_for_each(ent, from) {
             char * entry = ((char*)ent) - offset_ql;
 
-            mempcpy(new_entry, entry, sizeof_elem);
+            memcpy(new_entry, entry, sizeof_elem);
             struct qlist_head * new_entry_ql = (void*) (new_entry + offset_ql);
             new_entry_ql->prev = (void*)(new_entry - sizeof_elem + offset_ql);
             new_entry_ql->next = (void*)(new_entry + sizeof_elem + offset_ql);

--- a/src/network-workloads/model-net-mpi-replay.c
+++ b/src/network-workloads/model-net-mpi-replay.c
@@ -4407,7 +4407,9 @@ int modelnet_mpi_replay(MPI_Comm comm, int* argc, char*** argv )
     if (g_st_ev_trace || g_st_model_stats || g_st_use_analysis_lps)
         nw_lp_register_model();
 
+#ifdef USE_ZMQML
     director_lp_register_model("dir-nw-lp");
+#endif
     
    net_ids = model_net_configure(&num_nets);
 //   assert(num_nets == 1);

--- a/src/networks/model-net/dragonfly-dally.C
+++ b/src/networks/model-net/dragonfly-dally.C
@@ -1,14 +1,14 @@
 /*
  * Copyright (C) 2019, UChicago Argonne and co.
  * See LICENSE in top-level directory
- * 
+ *
  * Originally written by Misbah Mubarak
  * Updated by Neil McGlohon and Elkin Cruz-Camacho
- *  
+ *
  * A 1D specific dragonfly custom model - diverged from dragonfly-custom.C
  * Differs from dragonfly.C in that it allows for the custom features typically found in
  * dragonfly-custom.C.
- * 
+ *
  * This was not intended to be a long term solution, but enough changes had been made that merging
  * into dragonfly-custom.C wasn't feasible at the time of creation. Today, there is enough differences
  * in the two models that there is currently no plan to re-merge the two.
@@ -30,6 +30,7 @@
 #include <vector>
 #include <map>
 #include <set>
+#include <new>
 #include <algorithm>
 #include <errno.h>
 #include <sys/stat.h>
@@ -161,7 +162,7 @@ static int minimal_count=0, nonmin_count=0;
 static int num_routers_per_mgrp = 0;
 
 typedef struct dragonfly_param dragonfly_param;
-/* annotation-specific parameters (unannotated entry occurs at the 
+/* annotation-specific parameters (unannotated entry occurs at the
  * last index) */
 static uint64_t                  num_params = 0;
 static dragonfly_param         * all_params = NULL;
@@ -193,7 +194,7 @@ static void setup_packet_latency_path(char const * const dir_to_save);
 
 
 // ==== START OF Parameters to tune surrogate mode ====
-// 
+//
 static bool dally_surrogate_configured = false;
 static bool is_dally_surrogate_on = false;
 static bool freeze_network_on_switch = false;
@@ -216,7 +217,7 @@ struct terminal_dally_message_list {
     struct qlist_head list;
 };
 
-static void init_terminal_dally_message_list(terminal_dally_message_list *thisO, 
+static void init_terminal_dally_message_list(terminal_dally_message_list *thisO,
     terminal_dally_message *inmsg) {
     thisO->msg = *inmsg;
     thisO->event_data = NULL;
@@ -246,7 +247,7 @@ struct dragonfly_param
     int chunk_size; /* full-sized packets are broken into smaller chunks.*/
     int packet_size; /* maximum size of a packet, although we have no control over it. It is model-net who is in charge of generating packets of at most this size */
     int global_k_picks; /* k number of connections to select from when doing local adaptive routing */
-    int adaptive_threshold; 
+    int adaptive_threshold;
     int rail_select; // method by which rails are selected
     int num_parallel_switch_conns;
     // derived parameters
@@ -277,8 +278,8 @@ struct dragonfly_param
 
     //Xin: parameters for message counters of apps
     int counting_bool;
-    tw_stime counting_start; 
-    tw_stime counting_interval; 
+    tw_stime counting_start;
+    tw_stime counting_interval;
     int counting_windows;
     int num_apps;
 
@@ -468,7 +469,7 @@ static bool isRoutingSmart(int alg)
     if (alg == SMART_MINIMAL || alg == SMART_PROG_ADAPTIVE || alg == SMART_NON_MINIMAL)
         return true;
     else
-        return false;    
+        return false;
 }
 
 static bool isRoutingMinimal(int alg)
@@ -565,7 +566,7 @@ struct terminal_state
     tw_stime* last_buf_full; //[rail_id]
     tw_stime* busy_time; //[rail_id]
     uint64_t* link_traffic; //[rail_id]
-    
+
     unsigned long* total_chunks; //counter for when a packet is sent
     unsigned long* stalled_chunks; //Counter for when a packet cannot be immediately routed due to full VC - [rail_id]
 
@@ -589,7 +590,7 @@ struct terminal_state
     struct dfly_cn_sample * sample_stat;
     int op_arr_size;
     int max_arr_size;
-    
+
     /* for logging forward and reverse events */
     long fwd_events;
     long rev_events;
@@ -635,7 +636,7 @@ struct router_state
     int op_arr_size;
     int max_arr_size;
 
-    int* global_channel; 
+    int* global_channel;
 
     DragonflyConnectionManager connMan; //manages and organizes connections from this router
     rlc_state *local_congestion_controller;
@@ -671,12 +672,12 @@ struct router_state
 
     const char * anno;
     const dragonfly_param *params;
-    
+
     int** snapshot_data; //array of x numbers of snapshots of variable size
     char output_buf[4096];
 
     struct dfly_router_sample * rsamples;
-    
+
     long fwd_events;
     long rev_events;
 
@@ -712,14 +713,14 @@ st_model_types custom_dally_dragonfly_model_types[] = {
      sizeof(tw_lpid) + sizeof(long) * 2 + sizeof(double) + sizeof(tw_stime) *2,
      (sample_event_f) ross_dally_dragonfly_sample_fn,
      (sample_revent_f) ross_dally_dragonfly_sample_rc_fn,
-     sizeof(struct dfly_cn_sample) } , 
+     sizeof(struct dfly_cn_sample) } ,
     {(ev_trace_f) custom_dally_dragonfly_event_collect,
      sizeof(int),
      (model_stat_f) custom_dally_dfly_router_model_stat_collect,
      0, //updated in router_dally_init() since it's based on the radix
      (sample_event_f) ross_dally_dragonfly_rsample_fn,
      (sample_revent_f) ross_dally_dragonfly_rsample_rc_fn,
-     0 } , //updated in router_dally_init() since it's based on the radix    
+     0 } , //updated in router_dally_init() since it's based on the radix
     {NULL, 0, NULL, 0, NULL, NULL, 0}
 };
 /* End of ROSS model stats collection */
@@ -742,7 +743,7 @@ void custom_dally_dragonfly_model_stat_collect(terminal_state *s, tw_lp *lp, cha
     tw_lpid id = 0;
     long tmp = 0;
     tw_stime tmp2 = 0;
-    
+
     id = s->terminal_id;
     memcpy(&buffer[index], &id, sizeof(id));
     index += sizeof(id);
@@ -782,7 +783,7 @@ void custom_dally_dfly_router_model_stat_collect(router_state *s, tw_lp *lp, cha
 {
     (void)lp;
 
-    const dragonfly_param * p = s->params; 
+    const dragonfly_param * p = s->params;
     int i, index = 0;
 
     tw_lpid id = 0;
@@ -798,12 +799,12 @@ void custom_dally_dfly_router_model_stat_collect(router_state *s, tw_lp *lp, cha
         tmp = s->busy_time_ross_sample[i];
         memcpy(&buffer[index], &tmp, sizeof(tmp));
         index += sizeof(tmp);
-        s->busy_time_ross_sample[i] = 0; 
+        s->busy_time_ross_sample[i] = 0;
 
         tmp2 = s->link_traffic_ross_sample[i];
         memcpy(&buffer[index], &tmp2, sizeof(tmp2));
         index += sizeof(tmp2);
-        s->link_traffic_ross_sample[i] = 0; 
+        s->link_traffic_ross_sample[i] = 0;
     }
     return;
 }
@@ -834,7 +835,7 @@ static void ross_dally_dragonfly_rsample_fn(router_state * s, tw_bf * bf, tw_lp 
     (void)lp;
     (void)bf;
 
-    const dragonfly_param * p = s->params; 
+    const dragonfly_param * p = s->params;
     int i = 0;
 
     sample->router_id = s->router_id;
@@ -846,8 +847,8 @@ static void ross_dally_dragonfly_rsample_fn(router_state * s, tw_bf * bf, tw_lp 
 
     for(; i < p->radix; i++)
     {
-        sample->busy_time[i] = s->ross_rsample.busy_time[i]; 
-        sample->link_traffic_sample[i] = s->ross_rsample.link_traffic_sample[i]; 
+        sample->busy_time[i] = s->ross_rsample.busy_time[i];
+        sample->link_traffic_sample[i] = s->ross_rsample.link_traffic_sample[i];
     }
 
     /* clear up the current router stats */
@@ -865,7 +866,7 @@ static void ross_dally_dragonfly_rsample_rc_fn(router_state * s, tw_bf * bf, tw_
 {
     (void)lp;
     (void)bf;
-    
+
     const dragonfly_param * p = s->params;
     int i =0;
 
@@ -883,7 +884,7 @@ static void ross_dally_dragonfly_sample_fn(terminal_state * s, tw_bf * bf, tw_lp
 {
     (void)lp;
     (void)bf;
-    
+
     sample->terminal_id = s->terminal_id;
     sample->fin_chunks_sample = s->ross_sample.fin_chunks_sample;
     sample->data_size_sample = s->ross_sample.data_size_sample;
@@ -931,17 +932,17 @@ void dragonfly_dally_rsample_init(router_state * s,
     assert(p->radix);
 
     s->max_arr_size = MAX_STATS;
-    s->rsamples = (struct dfly_router_sample*)calloc(MAX_STATS, sizeof(struct dfly_router_sample)); 
+    s->rsamples = (struct dfly_router_sample*)calloc(MAX_STATS, sizeof(struct dfly_router_sample));
     for(; i < s->max_arr_size; i++)
     {
-        s->rsamples[i].busy_time = (tw_stime*)calloc(p->radix, sizeof(tw_stime)); 
+        s->rsamples[i].busy_time = (tw_stime*)calloc(p->radix, sizeof(tw_stime));
         s->rsamples[i].link_traffic_sample = (int64_t*)calloc(p->radix, sizeof(int64_t));
     }
 }
 
 void dragonfly_dally_rsample_rc_fn(router_state * s,
         tw_bf * bf,
-        terminal_dally_message * msg, 
+        terminal_dally_message * msg,
         tw_lp * lp)
 {
     (void)bf;
@@ -972,16 +973,16 @@ void dragonfly_dally_rsample_rc_fn(router_state * s,
 
 void dragonfly_dally_rsample_fn(router_state * s,
         tw_bf * bf,
-        terminal_dally_message * msg, 
+        terminal_dally_message * msg,
         tw_lp * lp)
 {
     (void)bf;
     (void)lp;
     (void)msg;
 
-    const dragonfly_param * p = s->params; 
+    const dragonfly_param * p = s->params;
 
-    if(s->op_arr_size >= s->max_arr_size) 
+    if(s->op_arr_size >= s->max_arr_size)
     {
         struct dfly_router_sample * tmp = (dfly_router_sample *)calloc((MAX_STATS + s->max_arr_size), sizeof(struct dfly_router_sample));
         memcpy(tmp, s->rsamples, s->op_arr_size * sizeof(struct dfly_router_sample));
@@ -991,7 +992,7 @@ void dragonfly_dally_rsample_fn(router_state * s,
     }
 
     int i = 0;
-    int cur_indx = s->op_arr_size; 
+    int cur_indx = s->op_arr_size;
 
     s->rsamples[cur_indx].router_id = s->router_id;
     s->rsamples[cur_indx].end_time = tw_now(lp);
@@ -1000,8 +1001,8 @@ void dragonfly_dally_rsample_fn(router_state * s,
 
     for(; i < p->radix; i++)
     {
-        s->rsamples[cur_indx].busy_time[i] = s->busy_time_sample[i]; 
-        s->rsamples[cur_indx].link_traffic_sample[i] = s->link_traffic_sample[i]; 
+        s->rsamples[cur_indx].busy_time[i] = s->busy_time_sample[i];
+        s->rsamples[cur_indx].link_traffic_sample[i] = s->link_traffic_sample[i];
     }
 
     s->op_arr_size++;
@@ -1040,10 +1041,10 @@ void dragonfly_dally_rsample_fin(router_state * s,
     }
         char rt_fn[MAX_NAME_LENGTH];
         if(strcmp(router_sample_file, "") == 0)
-            sprintf(rt_fn, "dragonfly-router-sampling-%ld.bin", g_tw_mynode); 
+            sprintf(rt_fn, "dragonfly-router-sampling-%ld.bin", g_tw_mynode);
         else
             sprintf(rt_fn, "%s-%ld.bin", router_sample_file, g_tw_mynode);
-        
+
         int i = 0;
 
         int size_sample = sizeof(tw_lpid) + p->radix * (sizeof(int64_t) + sizeof(tw_stime)) + sizeof(tw_stime) + 2 * sizeof(long);
@@ -1079,13 +1080,13 @@ void dragonfly_dally_sample_init(terminal_state * s,
     s->sample_stat = (dfly_cn_sample *)calloc(MAX_STATS, sizeof(struct dfly_cn_sample));
     for(int i = 0; i < s->max_arr_size; i++)
     {
-        s->sample_stat[i].busy_time_sample = (tw_stime*)calloc(s->params->num_rails, sizeof(tw_stime)); 
+        s->sample_stat[i].busy_time_sample = (tw_stime*)calloc(s->params->num_rails, sizeof(tw_stime));
     }
-    
+
 }
 void dragonfly_dally_sample_rc_fn(terminal_state * s,
         tw_bf * bf,
-        terminal_dally_message * msg, 
+        terminal_dally_message * msg,
         tw_lp * lp)
 {
     (void)lp;
@@ -1124,7 +1125,7 @@ void dragonfly_dally_sample_fn(terminal_state * s,
     (void)lp;
     (void)msg;
     (void)bf;
-    
+
     if(s->op_arr_size >= s->max_arr_size)
     {
         /* In the worst case, copy array to a new memory location, its very
@@ -1135,7 +1136,7 @@ void dragonfly_dally_sample_fn(terminal_state * s,
         s->sample_stat = tmp;
         s->max_arr_size += MAX_STATS;
     }
-    
+
     int cur_indx = s->op_arr_size;
 
     s->sample_stat[cur_indx].terminal_id = s->terminal_id;
@@ -1164,10 +1165,10 @@ void dragonfly_dally_sample_fin(terminal_state * s,
         tw_lp * lp)
 {
     (void)lp;
- 
+
     if(!g_tw_mynode)
     {
-    
+
         /* write metadata file */
         char meta_fname[64];
         sprintf(meta_fname, "dragonfly-cn-sampling.meta");
@@ -1181,7 +1182,7 @@ void dragonfly_dally_sample_fin(terminal_state * s,
 
         char rt_fn[MAX_NAME_LENGTH];
         if(strncmp(cn_sample_file, "", 10) == 0)
-            sprintf(rt_fn, "dragonfly-cn-sampling-%ld.bin", g_tw_mynode); 
+            sprintf(rt_fn, "dragonfly-cn-sampling-%ld.bin", g_tw_mynode);
         else
             sprintf(rt_fn, "%s-%ld.bin", cn_sample_file, g_tw_mynode);
 
@@ -1251,7 +1252,7 @@ static int dragonfly_rank_hash_compare(
     struct dfly_qhash_entry *tmp = NULL;
 
     tmp = qhash_entry(link, struct dfly_qhash_entry, hash_link);
-    
+
     if (tmp->key.message_id == message_key->message_id && tmp->key.sender_id == message_key->sender_id)
         return 1;
 
@@ -1260,13 +1261,13 @@ static int dragonfly_rank_hash_compare(
 static int dragonfly_hash_func(void *k, int table_size)
 {
     struct dfly_hash_key *tmp = (struct dfly_hash_key *)k;
-    uint32_t pc = 0, pb = 0;	
+    uint32_t pc = 0, pb = 0;
     bj_hashlittle2(tmp, sizeof(*tmp), &pc, &pb);
     return (int)(pc % (table_size - 1));
     /*uint64_t key = (~tmp->message_id) + (tmp->message_id << 18);
     key = key * 21;
     key = ~key ^ (tmp->sender_id >> 4);
-    key = key * tmp->sender_id; 
+    key = key * tmp->sender_id;
     return (int)(key & (table_size - 1));*/
 }
 
@@ -1293,10 +1294,10 @@ int dragonfly_dally_get_msg_sz(void)
 
 static void free_tmp(void * ptr)
 {
-    struct dfly_qhash_entry * dfly = (dfly_qhash_entry *)ptr; 
+    struct dfly_qhash_entry * dfly = (dfly_qhash_entry *)ptr;
     if(dfly->remote_event_data)
         free(dfly->remote_event_data);
-   
+
     if(dfly)
         free(dfly);
 }
@@ -1313,7 +1314,7 @@ static int dfdally_get_assigned_router_id_from_terminal(const dragonfly_param *p
     if(num_planes == 1) //then all rails go to the same router //TODO: this could change - could be cool!
     {
         if(num_rails == 1) //default behavior
-            return term_gid / num_cn_per_router; 
+            return term_gid / num_cn_per_router;
         else
         {
             return term_gid / num_cn_per_router; // all rails go to same router - perhaps change this
@@ -1336,7 +1337,7 @@ static int dfdally_get_assigned_router_id_from_terminal(const dragonfly_param *p
             return -1;
         }
     }
-    
+
 }
 
 static int dfdally_score_connection(router_state *s, tw_bf *bf, terminal_dally_message *msg, tw_lp *lp, Connection conn, conn_minimality_t c_minimality)
@@ -1407,12 +1408,12 @@ static Connection get_absolute_best_connection_from_conns(router_state *s, tw_bf
             }
             else {
                 best_conns.push_back(conns[i]);
-            }         
+            }
         }
     }
 
     assert(best_conns.size() > 0);
-    
+
     msg->num_rngs++;
     return best_conns[tw_rand_integer(lp->rng, 0, best_conns.size()-1)];
 }
@@ -1454,7 +1455,7 @@ static Connection get_absolute_best_connection_from_conn_set(router_state *s, tw
     }
 
     assert(best_conns.size() > 0);
-    
+
     msg->num_rngs++;
     return best_conns[tw_rand_integer(lp->rng, 0, best_conns.size()-1)];
 }
@@ -1848,13 +1849,13 @@ void dragonfly_print_params(const dragonfly_param *p, FILE * st)
 static void dragonfly_read_config(const char * anno, dragonfly_param *params)
 {
     /*Adding init for router magic number*/
-    uint32_t h1 = 0, h2 = 0; 
+    uint32_t h1 = 0, h2 = 0;
     bj_hashlittle2(LP_METHOD_NM_ROUT, strlen(LP_METHOD_NM_ROUT), &h1, &h2);
     router_magic_num = h1 + h2;
-    
+
     bj_hashlittle2(LP_METHOD_NM_TERM, strlen(LP_METHOD_NM_TERM), &h1, &h2);
     terminal_magic_num = h1 + h2;
-    
+
     // shorthand
     dragonfly_param *p = params;
     int myRank;
@@ -1966,13 +1967,13 @@ static void dragonfly_read_config(const char * anno, dragonfly_param *params)
             MAX_NAME_LENGTH);
     configuration_get_value(&config, "PARAMS", "rt_sample_file", anno, router_sample_file,
             MAX_NAME_LENGTH);
-    
+
     char routing_str[MAX_NAME_LENGTH];
     configuration_get_value(&config, "PARAMS", "routing", anno, routing_str,
             MAX_NAME_LENGTH);
     if(strcmp(routing_str, "minimal") == 0)
         routing = MINIMAL;
-    else if(strcmp(routing_str, "nonminimal")==0 || 
+    else if(strcmp(routing_str, "nonminimal")==0 ||
             strcmp(routing_str,"non-minimal")==0)
         routing = NON_MINIMAL;
     else if (strcmp(routing_str, "adaptive") == 0)
@@ -2071,7 +2072,7 @@ static void dragonfly_read_config(const char * anno, dragonfly_param *params)
     }
 
     p->num_vcs = 4;
-    
+
     if(p->num_qos_levels > 1)
         p->num_vcs = p->num_qos_levels * p->num_vcs;
 
@@ -2097,12 +2098,12 @@ static void dragonfly_read_config(const char * anno, dragonfly_param *params)
     if(rc) {
         tw_error(TW_LOC, "\nnum_groups not specified, Aborting\n");
     }
-    
+
     rc = configuration_get_value_int(&config, "PARAMS", "num_routers", anno, &p->num_routers);
     if(rc) {
         tw_error(TW_LOC, "\nnum_routers not specified, Aborting\n");
     }
-    
+
     rc = configuration_get_value_int(&config, "PARAMS", "num_cns_per_router", anno, &p->num_cn);
     if(rc) {
         if(!myRank)
@@ -2138,7 +2139,7 @@ static void dragonfly_read_config(const char * anno, dragonfly_param *params)
     // read intra group connections, store from a router's perspective
     // all links to the same router form a vector
     char intraFile[MAX_NAME_LENGTH] = {'\0'};
-    configuration_get_value(&config, "PARAMS", "intra-group-connections", 
+    configuration_get_value(&config, "PARAMS", "intra-group-connections",
         anno, intraFile, MAX_NAME_LENGTH);
     if (strlen(intraFile) <= 0) {
       tw_error(TW_LOC, "Intra group connections file not specified. Aborting");
@@ -2195,7 +2196,7 @@ static void dragonfly_read_config(const char * anno, dragonfly_param *params)
     // read inter group connections, store from a router's perspective
     // also create a group level table that tells all the connecting routers
     char interFile[MAX_NAME_LENGTH] = {'\0'};
-    configuration_get_value(&config, "PARAMS", "inter-group-connections", 
+    configuration_get_value(&config, "PARAMS", "inter-group-connections",
         anno, interFile, MAX_NAME_LENGTH);
     if(strlen(interFile) <= 0) {
         tw_error(TW_LOC, "Inter group connections file not specified. Aborting");
@@ -2264,7 +2265,7 @@ static void dragonfly_read_config(const char * anno, dragonfly_param *params)
 
     if (strlen(g_nm_link_failure_filepath) == 0) //was this defined already via a command line argument?
     {
-        configuration_get_value(&config, "PARAMS", "link-failure-file", 
+        configuration_get_value(&config, "PARAMS", "link-failure-file",
             anno, failureFileName, MAX_NAME_LENGTH);
         if (strlen(failureFileName) > 0) {
             netMan.enable_link_failures();
@@ -2293,8 +2294,8 @@ static void dragonfly_read_config(const char * anno, dragonfly_param *params)
             netMan.add_link_failure_info(link);
         }
     }
-    
-    netMan.solidify_network(); //finalize link failures and burn the network links into the connection managers 
+
+    netMan.solidify_network(); //finalize link failures and burn the network links into the connection managers
 
     if (DUMP_CONNECTIONS)
     {
@@ -2347,7 +2348,7 @@ static void dragonfly_read_config(const char * anno, dragonfly_param *params)
     }
 
     double general_credit_delay;
-    int credit_delay_unset = configuration_get_value_double(&config, "PARAMS", "credit_delay", anno, &general_credit_delay); 
+    int credit_delay_unset = configuration_get_value_double(&config, "PARAMS", "credit_delay", anno, &general_credit_delay);
     int local_credit_delay_unset = configuration_get_value_double(&config, "PARAMS", "local_credit_delay", anno, &p->local_credit_delay);
     int global_credit_delay_unset = configuration_get_value_double(&config, "PARAMS", "global_credit_delay", anno, &p->global_credit_delay);
     int cn_credit_delay_unset = configuration_get_value_double(&config, "PARAMS", "cn_credit_delay", anno, &p->cn_credit_delay);
@@ -2365,7 +2366,7 @@ static void dragonfly_read_config(const char * anno, dragonfly_param *params)
     //If the user specifies a general "credit_delay" AND any of the more specific credit delays, throw an error to make sure they correct their configuration
     if (!credit_delay_unset && !(local_credit_delay_unset || global_credit_delay_unset || cn_credit_delay_unset))
         tw_error(TW_LOC, "\nCannot set both a general credit delay and specific (local/global/cn) credit delays. Check configuration file.");
-    
+
     //If the user specifies ANY credit delays general or otherwise AND has the auto credit delay flag enabled, throw an error to make sure they correct the conflicting configuration
     if ((!credit_delay_unset || !local_credit_delay_unset || !global_credit_delay_unset || !cn_credit_delay_unset) && auto_credit_delay_flag)
         tw_error(TW_LOC, "\nCannot set both a credit delay (general or specific) and also enable auto credit delay calculation. Check Configuration file.");
@@ -2391,7 +2392,7 @@ static void dragonfly_read_config(const char * anno, dragonfly_param *params)
         if (global_credit_delay_unset) {
             p->global_credit_delay = bytes_to_ns(p->credit_size, p->global_bandwidth);
             if(!myRank && !auto_credit_delay_flag)
-                fprintf(stderr, "global_credit_delay not specified, using calculation based on global bandwidth: %.2f\n", p->global_credit_delay);   
+                fprintf(stderr, "global_credit_delay not specified, using calculation based on global bandwidth: %.2f\n", p->global_credit_delay);
         }
         if (cn_credit_delay_unset) {
             p->cn_credit_delay = bytes_to_ns(p->credit_size, p->cn_bandwidth);
@@ -2404,7 +2405,7 @@ static void dragonfly_read_config(const char * anno, dragonfly_param *params)
         p->local_credit_delay = general_credit_delay;
         p->global_credit_delay = general_credit_delay;
         p->cn_credit_delay = general_credit_delay;
-        
+
         if(!myRank)
             fprintf(stderr, "general credit_delay specified - all credit delays set to %.2f\n",general_credit_delay);
     }
@@ -2422,7 +2423,7 @@ static void dragonfly_read_config(const char * anno, dragonfly_param *params)
         if(!myRank) {
             if (cc_enabled)
                 fprintf(stderr,"\nCongestion Control Enabled\n");
-            else 
+            else
                 fprintf(stderr,"\nCongestion Control Disabled\n");
 
         }
@@ -2550,7 +2551,7 @@ void dragonfly_dally_configure() {
 
 static void setup_packet_latency_path(char const * const dir_to_save) {
     assert(packet_latency_f == NULL);
-    // checking 
+    // checking
     int const NO_ERROR = 0;
     struct stat st;
     memset(&st, 0, sizeof(struct stat));
@@ -2591,7 +2592,7 @@ void dragonfly_dally_report_stats()
     MPI_Reduce( &total_msg_sz, &final_msg_sz, 1, MPI_LONG_LONG, MPI_SUM, 0, MPI_COMM_CODES);
     MPI_Reduce( &dragonfly_total_time, &avg_time, 1,MPI_DOUBLE, MPI_SUM, 0, MPI_COMM_CODES);
     MPI_Reduce( &dragonfly_max_latency, &max_time, 1, MPI_DOUBLE, MPI_MAX, 0, MPI_COMM_CODES);
-    
+
     MPI_Reduce( &packet_gen, &total_gen, 1, MPI_LONG, MPI_SUM, 0, MPI_COMM_CODES);
     MPI_Reduce(&packet_fin, &total_fin, 1, MPI_LONG, MPI_SUM, 0, MPI_COMM_CODES);
     MPI_Reduce( &num_local_packets_sr, &total_local_packets_sr, 1, MPI_LONG, MPI_SUM, 0, MPI_COMM_CODES);
@@ -2611,16 +2612,16 @@ void dragonfly_dally_report_stats()
     }
     /* print statistics */
     if(!g_tw_mynode)
-    {	
-        if (PRINT_CONFIG) 
+    {
+        if (PRINT_CONFIG)
             dragonfly_print_params(stored_params, NULL);
 
-        printf("\nAverage number of hops traversed %f average chunk latency %lf us maximum chunk latency %lf us avg message size %lf bytes finished messages %lld finished chunks %lld\n", 
+        printf("\nAverage number of hops traversed %f average chunk latency %lf us maximum chunk latency %lf us avg message size %lf bytes finished messages %lld finished chunks %lld\n",
                 (float)avg_hops/total_finished_chunks, (float) avg_time/total_finished_chunks/1000, max_time/1000, (float)final_msg_sz/total_finished_msgs, total_finished_msgs, total_finished_chunks);
         if(routing == ADAPTIVE || routing == PROG_ADAPTIVE || routing == PROG_ADAPTIVE_LEGACY || SHOW_ADAP_STATS)
-                printf("\nADAPTIVE ROUTING STATS: %d chunks routed minimally %d chunks routed non-minimally completed packets %lld \n", 
+                printf("\nADAPTIVE ROUTING STATS: %d chunks routed minimally %d chunks routed non-minimally completed packets %lld \n",
                         total_minimal_packets, total_nonmin_packets, total_finished_chunks);
-    
+
         printf("\nTotal packets generated %ld finished %ld Locally routed- same router %ld different-router %ld Remote (inter-group) %ld \n", total_gen, total_fin, total_local_packets_sr, total_local_packets_sg, total_remote_packets);
     }
     return;
@@ -2692,7 +2693,7 @@ static int get_term_bandwidth_consumption(terminal_state * s, int rail_id, int q
 {
     assert(qos_lvl >= Q_HIGH && qos_lvl <= Q_LOW);
 
-    //tw_stime reset_window_s = ns_to_s(bw_reset_window); 
+    //tw_stime reset_window_s = ns_to_s(bw_reset_window);
     //double bw_gib = bytes_to_gigabytes(s->qos_data[qos_lvl]);
 
     //double bw_consumed = ((double)bw_gib / (double)reset_window_s);
@@ -2736,10 +2737,10 @@ static void issue_bw_monitor_event_rc(terminal_state * s, tw_bf * bf, terminal_d
     int num_qos_levels = s->params->num_qos_levels;
     int num_rails = s->params->num_rails;
 
-    
+
     if(msg->rc_is_qos_set == 1)
     {
-        for(int i = 0; i < num_rails; i++) 
+        for(int i = 0; i < num_rails; i++)
         {
             for(int j = 0; j < num_qos_levels; j++)
             {
@@ -2752,14 +2753,14 @@ static void issue_bw_monitor_event_rc(terminal_state * s, tw_bf * bf, terminal_d
         free(msg->rc_qos_status);
         msg->rc_is_qos_set = 0;
     }
-    
+
 }
 /* resets the bandwidth numbers recorded so far */
 static void issue_bw_monitor_event(terminal_state * s, tw_bf * bf, terminal_dally_message * msg, tw_lp * lp)
 {
     int num_qos_levels = s->params->num_qos_levels;
     int num_rails = s->params->num_rails;
-    
+
     //RC data storage start.
     //Allocate memory here for these pointers that are stored in the events. FREE THESE IN RC OR IN COMMIT_F
     msg->rc_qos_data = (unsigned long long *) calloc(num_rails*num_qos_levels, sizeof(unsigned long long));
@@ -2789,12 +2790,12 @@ static void issue_bw_monitor_event(terminal_state * s, tw_bf * bf, terminal_dall
     }
 
     if (s->workloads_finished_flag == 0) {
-        terminal_dally_message * m; 
+        terminal_dally_message * m;
         tw_stime bw_ts = bw_reset_window + gen_noise(lp, &msg->num_rngs);
         tw_event * e = model_net_method_event_new(lp->gid, bw_ts, lp, DRAGONFLY_DALLY,
-                (void**)&m, NULL); 
+                (void**)&m, NULL);
         m->type = T_BANDWIDTH;
-        m->magic = terminal_magic_num; 
+        m->magic = terminal_magic_num;
         tw_event_send(e);
     }
 }
@@ -2825,7 +2826,7 @@ static void issue_rtr_bw_monitor_event(router_state *s, tw_bf *bf, terminal_dall
 {
     int radix = s->params->radix;
     int num_qos_levels = s->params->num_qos_levels;
-    
+
 
     //RC data storage start.
     //Allocate memory here for these pointers that are stored in the events. FREE THESE IN RC OR IN COMMIT_F
@@ -2850,8 +2851,8 @@ static void issue_rtr_bw_monitor_event(router_state *s, tw_bf *bf, terminal_dall
         for(int j = 0; j < num_qos_levels; j++)
         {
             int bw_consumed = get_rtr_bandwidth_consumption(s, j, i);
-        
-            #if DEBUG_QOS == 1 
+
+            #if DEBUG_QOS == 1
             if(dragonfly_rtr_bw_log != NULL && ROUTER_BW_LOG)
             {
                 if(s->qos_data[i][j] > 0)
@@ -2859,7 +2860,7 @@ static void issue_rtr_bw_monitor_event(router_state *s, tw_bf *bf, terminal_dall
                     fprintf(dragonfly_rtr_bw_log, "\n %d %f %d %d %d %d %d %f", s->router_id, tw_now(lp), i, j, bw_consumed, s->qos_status[i][j], s->qos_data[i][j], s->busy_time_sample[i]);
                 }
             }
-            #endif   
+            #endif
         }
     }
 
@@ -2889,7 +2890,7 @@ static void issue_rtr_bw_monitor_event(router_state *s, tw_bf *bf, terminal_dall
 static int get_next_vcg(terminal_state * s, tw_bf * bf, terminal_dally_message * msg, tw_lp * lp)
 {
     int num_qos_levels = s->params->num_qos_levels;
-    
+
     if(num_qos_levels == 1)
     {
         if(qlist_empty(&s->terminal_msgs[msg->rail_id][0]) || s->vc_occupancy[msg->rail_id][0] + s->params->chunk_size > s->params->cn_vc_size)
@@ -2906,7 +2907,7 @@ static int get_next_vcg(terminal_state * s, tw_bf * bf, terminal_dally_message *
         if(s->qos_status[msg->rail_id][k] != Q_OVERBW)
         {
             bw_consumption[k] = get_term_bandwidth_consumption(s, msg->rail_id, k);
-            if(bw_consumption[k] > s->params->qos_bandwidths[k]) 
+            if(bw_consumption[k] > s->params->qos_bandwidths[k])
             {
                 if(k == 0)
                     msg->qos_reset1 = 1;
@@ -2939,10 +2940,10 @@ static int get_next_vcg(terminal_state * s, tw_bf * bf, terminal_dally_message *
         if(!qlist_empty(&s->terminal_msgs[msg->rail_id][i]) && s->vc_occupancy[msg->rail_id][i] + s->params->chunk_size <= s->params->cn_vc_size)
         {
             bf->c2 = 1;
-            
+
             if(msg->last_saved_qos < 0)
                 msg->last_saved_qos = s->last_qos_lvl[msg->rail_id];
-            
+
             s->last_qos_lvl[msg->rail_id] = next_rr_vcg;
             return i;
         }
@@ -2959,7 +2960,7 @@ static int get_next_router_vcg(router_state * s, tw_bf * bf, terminal_dally_mess
     int output_port = msg->vc_index;
     int vcg = 0;
     int base_limit = 0;
-        
+
     int chunk_size = s->params->chunk_size;
     int bw_consumption[num_qos_levels];
     /* First make sure the bandwidth consumptions are up to date. */
@@ -2970,11 +2971,11 @@ static int get_next_router_vcg(router_state * s, tw_bf * bf, terminal_dally_mess
             if(s->qos_status[output_port][k] != Q_OVERBW)
             {
                 bw_consumption[k] = get_rtr_bandwidth_consumption(s, k, output_port);
-                if(bw_consumption[k] > s->params->qos_bandwidths[k]) 
+                if(bw_consumption[k] > s->params->qos_bandwidths[k])
                 {
         //            printf("\n Router %d QoS %d exceeded allowed bandwidth %d ", s->router_id, k, bw_consumption[k]);
                     if(k == 0)
-                        msg->qos_reset1 = 1;   
+                        msg->qos_reset1 = 1;
                     else if(k == 1)
                         msg->qos_reset2 = 1;
 
@@ -3001,7 +3002,7 @@ static int get_next_router_vcg(router_state * s, tw_bf * bf, terminal_dally_mess
             }
         }
     }
-        
+
     /* All vcgs are exceeding their bandwidth limits*/
     msg->last_saved_qos = s->last_qos_lvl[output_port]; // last_qos_lvl stores a vc# not a qos# for routers. Terminals store qos#
     //int next_rr_vcg = (s->last_qos_lvl[output_port] + 1) % num_qos_levels;
@@ -3124,7 +3125,7 @@ static void dragonfly_dally_terminal_highdef_to_surrogate(
 
         // The packet has not been delievered. Send directly to destination and notify of zombie event
         if (freeze_network_on_switch) {
-            struct packet_end predicted_end = 
+            struct packet_end predicted_end =
                 terminal_predictor->predict(s->predictor_data, lp, s->terminal_id, &sent.start);
 
             double latency = predicted_end.travel_end_time - tw_now(lp);
@@ -3431,7 +3432,7 @@ static void terminal_commit_packet_generate(terminal_state * s, tw_bf * bf, term
         assert(s->sent_packets[s->last_packet_sent_id].next_packet_delay == -1);
         s->sent_packets[s->last_packet_sent_id].next_packet_delay = processing_packet_delay;
     }
-    
+
     // If we already received the (previous) last packet latency, we inject it now into the predictor
     if (s->arrival_of_last_packet.packet_ID != -1) {
         assert(s->arrival_of_last_packet.packet_ID == s->last_packet_sent_id);
@@ -3445,8 +3446,8 @@ static void terminal_commit_packet_generate(terminal_state * s, tw_bf * bf, term
 }
 
 static void terminal_dally_commit(terminal_state * s,
-		tw_bf * bf, 
-		terminal_dally_message * msg, 
+		tw_bf * bf,
+		terminal_dally_message * msg,
         tw_lp * lp)
 {
 
@@ -3518,7 +3519,7 @@ static void terminal_dally_commit(terminal_state * s,
 
         case T_ARRIVE_PREDICTED:
         break;
-        
+
         case T_SEND:
             if (freeze_network_on_switch) {
                 if (bf->c16 && s->is_pending_local_send.count(msg->packet_ID) == 1) {
@@ -3526,10 +3527,10 @@ static void terminal_dally_commit(terminal_state * s,
                 }
             }
         break;
-        
+
         case T_BUFFER:
         break;
-    
+
         case T_BANDWIDTH:
             if(msg->rc_is_qos_set == 1) {
                 free(msg->rc_qos_data);
@@ -3537,7 +3538,7 @@ static void terminal_dally_commit(terminal_state * s,
                 msg->rc_is_qos_set = 0;
             }
         break;
-    
+
         case T_NOTIFY:
             if(msg->notify_type == NOTIFY_LATENCY) {
                 assert(lp->gid == msg->src_terminal_id);
@@ -3571,8 +3572,8 @@ static void terminal_dally_commit(terminal_state * s,
 }
 
 static void router_dally_commit(router_state * s,
-		tw_bf * bf, 
-		terminal_dally_message * msg, 
+		tw_bf * bf,
+		terminal_dally_message * msg,
         tw_lp * lp)
 {
     if(msg->type == R_BANDWIDTH)
@@ -3667,6 +3668,12 @@ static void terminal_dally_init( terminal_state * s, tw_lp * lp )
     s->router_id = (unsigned int*)calloc(p->num_rails, sizeof(unsigned int));
     s->router_lp = (tw_lpid*)calloc(p->num_rails, sizeof(tw_lpid));
 
+    // ROSS allocates LP state as a zeroed POD blob and never runs C++ ctors.
+    // Assigning into a never-constructed map-of-maps is UB; libc++ (macOS)
+    // segfaults walking the begin-node sentinel, libstdc++ (Linux) tolerates
+    // the zero-init and can produce nondeterministic test failures.
+    // TODO: drop once make_lptype<T>() trampoline lands.
+    new (&s->connMan) DragonflyConnectionManager();
     s->connMan = netMan.get_connection_manager_for_terminal(s->terminal_id);
 
 
@@ -3681,7 +3688,7 @@ static void terminal_dally_init( terminal_state * s, tw_lp * lp )
     s->terminal_available_time = (tw_stime*)calloc(p->num_rails, sizeof(tw_stime));
     s->packet_counter = 0;
     s->min_latency = INT_MAX;
-    s->max_latency = 0;  
+    s->max_latency = 0;
 
     s->link_traffic=(uint64_t*)calloc(p->num_rails, sizeof(uint64_t));
     s->finished_msgs = 0;
@@ -3709,7 +3716,7 @@ static void terminal_dally_init( terminal_state * s, tw_lp * lp )
     s->last_buf_full = (tw_stime*)calloc(p->num_rails, sizeof(tw_stime));
 
     s->terminal_length = (int**)calloc(p->num_rails, sizeof(int*)); //1 vc times number of qos levels
-    
+
     for(i = 0; i < p->num_rails; i++)
     {
         s->vc_occupancy[i]= (int*)calloc(num_qos_levels, sizeof(int));
@@ -3794,7 +3801,7 @@ static void terminal_dally_init( terminal_state * s, tw_lp * lp )
     return;
 }
 
-/* sets up the router virtual channels, global channels, 
+/* sets up the router virtual channels, global channels,
  * local channels, compute node channels */
 static void router_dally_init(router_state * r, tw_lp * lp)
 {
@@ -3825,7 +3832,7 @@ static void router_dally_init(router_state * r, tw_lp * lp)
     r->router_id = codes_mapping_get_lp_relative_id(lp->gid, 0, 0);
     r->plane_id = r->router_id / p->num_routers_per_plane;
     r->group_id=r->router_id/p->num_routers;
-    
+
     char rtr_bw_log[128];
     sprintf(rtr_bw_log, "router-bw-tracker-%lu", g_tw_mynode);
 
@@ -3846,8 +3853,10 @@ static void router_dally_init(router_state * r, tw_lp * lp)
 
     int num_qos_levels = p->num_qos_levels;
 
+    // TODO: drop once make_lptype<T>() trampoline lands.
+    new (&r->connMan) DragonflyConnectionManager();
     r->connMan = netMan.get_connection_manager_for_router(r->router_id);
-    
+
     r->vc_max_sizes = (int*)calloc(p->radix, sizeof(int));
     for(int i = 0; i < p->radix; i++)
     {
@@ -3887,9 +3896,9 @@ static void router_dally_init(router_state * r, tw_lp * lp)
     r->qos_data = (int**)calloc(p->radix, sizeof(int*));
     r->last_qos_lvl = (int*)calloc(p->radix, sizeof(int));
     r->qos_status = (int**)calloc(p->radix, sizeof(int*));
-    r->pending_msgs = 
+    r->pending_msgs =
         (struct qlist_head**)calloc(p->radix, sizeof(struct qlist_head*));
-    r->queued_msgs = 
+    r->queued_msgs =
         (struct qlist_head**)calloc(p->radix, sizeof(struct qlist_head*));
     r->queued_count = (int*)calloc(p->radix, sizeof(int));
     r->last_buf_full = (tw_stime*)calloc(p->radix, sizeof(tw_stime*));
@@ -3919,7 +3928,7 @@ static void router_dally_init(router_state * r, tw_lp * lp)
         r->last_qos_lvl[i] = 0;
         r->link_traffic[i]=0;
         r->link_traffic_sample[i] = 0;
-        r->queued_count[i] = 0;    
+        r->queued_count[i] = 0;
         r->in_send_loop[i] = 0;
         r->vc_occupancy[i] = (int*)calloc(p->num_vcs, sizeof(int));
     //    printf("\n Number of vcs %d for radix %d ", p->num_vcs, p->radix);
@@ -3932,7 +3941,7 @@ static void router_dally_init(router_state * r, tw_lp * lp)
             r->qos_status[i][j] = Q_ACTIVE;
             r->qos_data[i][j] = 0;
         }
-        for(int j = 0; j < p->num_vcs; j++) 
+        for(int j = 0; j < p->num_vcs; j++)
         {
             INIT_QLIST_HEAD(&r->pending_msgs[i][j]);
             INIT_QLIST_HEAD(&r->queued_msgs[i][j]);
@@ -3945,7 +3954,7 @@ static void router_dally_init(router_state * r, tw_lp * lp)
     if (g_congestion_control_enabled) {
         r->local_congestion_controller = (rlc_state*)calloc(1,sizeof(rlc_state));
         cc_router_local_controller_init(r->local_congestion_controller, lp, p->total_terminals, r->router_id, p->radix, p->num_vcs, r->vc_max_sizes, r->port_bandwidths, &r->workloads_finished_flag);
-        
+
         vector<Connection> terminal_out_conns = r->connMan.get_connections_by_type(CONN_TERMINAL);
         vector<Connection>::iterator it = terminal_out_conns.begin();
         for(; it != terminal_out_conns.end(); it++)
@@ -3979,11 +3988,11 @@ static void router_dally_init(router_state * r, tw_lp * lp)
         router_send_snapshot_events(r, lp);
     }
 
-    //Xin: msg counters for apps 
+    //Xin: msg counters for apps
     r->agg_link_traffic = NULL;
     r->agg_busy_time = NULL;
     if(p->counting_bool > 0)
-    {   
+    {
         r->agg_link_traffic = (int64_t **) calloc(p->counting_windows, sizeof(int64_t *));
         r->agg_busy_time = (tw_stime **) malloc (p->counting_windows * sizeof(tw_stime *));
 
@@ -3998,7 +4007,7 @@ static void router_dally_init(router_state * r, tw_lp * lp)
     }
 
     return;
-}	
+}
 
 /* dragonfly packet event reverse handler */
 static void dragonfly_dally_packet_event_rc(tw_lp *sender)
@@ -4054,7 +4063,7 @@ static tw_stime dragonfly_dally_packet_event(
     msg->message_id = req->msg_id;
     msg->is_pull = req->is_pull;
     msg->pull_size = req->pull_size;
-    msg->magic = terminal_magic_num; 
+    msg->magic = terminal_magic_num;
     msg->msg_start_time = req->msg_start_time;
     msg->msg_new_mn_event = req->msg_new_mn_event;
     msg->rail_id = req->queue_offset;
@@ -4129,7 +4138,7 @@ static void packet_generate_predicted(terminal_state * s, tw_bf * bf, terminal_d
         .is_there_another_pckt_in_queue = msg->is_there_another_pckt_in_queue
     };
 
-    struct packet_end const end = 
+    struct packet_end const end =
         terminal_predictor->predict(s->predictor_data, lp, s->terminal_id, &start);
     double const latency = end.travel_end_time - start.travel_start_time;
     double const arrival = start.travel_start_time + latency; // this is "equivalent" to end.travel_end_time
@@ -4216,7 +4225,7 @@ static void packet_generate_rc(terminal_state * s, tw_bf * bf, terminal_dally_me
     int num_qos_levels = s->params->num_qos_levels;
     if(bf->c1)
         s->is_monitoring_bw = 0;
-    
+
     s->total_gen_size -= msg->packet_size;
     s->packet_gen--;
     packet_gen--;
@@ -4237,7 +4246,7 @@ static void packet_generate_rc(terminal_state * s, tw_bf * bf, terminal_dally_me
     int vcg = 0;
     if(num_qos_levels > 1)
     {
-        vcg = get_vcg_from_category(msg); 
+        vcg = get_vcg_from_category(msg);
         assert(vcg == Q_HIGH || vcg == Q_MEDIUM);
     }
     assert(vcg < num_qos_levels);
@@ -4343,7 +4352,7 @@ static void packet_generate(terminal_state * s, tw_bf * bf, terminal_dally_messa
                     // }
                 }
             }
-            if (valid_rails.size() < 1) { 
+            if (valid_rails.size() < 1) {
                 tw_error(TW_LOC,"Invalid Connections in Network due to link failures!\n");
                 // valid_rails = injection_connections; //TODO will cause problems - deal with
             }
@@ -4351,7 +4360,7 @@ static void packet_generate(terminal_state * s, tw_bf * bf, terminal_dally_messa
         else {
             valid_rails = injection_connections;
         }
-        
+
         vector< Connection > tied_rails;
 
         //determine rail
@@ -4372,7 +4381,7 @@ static void packet_generate(terminal_state * s, tw_bf * bf, terminal_dally_messa
                 }
 
             }
-            
+
             if (s->params->rail_select == RAIL_PATH) {
                 int path_lens[valid_rails.size()];
                 int min_len = 99999;
@@ -4456,7 +4465,7 @@ static void packet_generate(terminal_state * s, tw_bf * bf, terminal_dally_messa
         dest_router_id = dfdally_get_assigned_router_id_from_terminal(p, msg->dfdally_dest_terminal_id, 0);
     }
     int dest_grp_id = dest_router_id / s->params->num_routers;
-    int src_grp_id = s->router_id[msg->rail_id] / s->params->num_routers; 
+    int src_grp_id = s->router_id[msg->rail_id] / s->params->num_routers;
 
     if(src_grp_id == dest_grp_id)
     {
@@ -4476,7 +4485,7 @@ static void packet_generate(terminal_state * s, tw_bf * bf, terminal_dally_messa
         bf->c4 = 1;
         num_remote_packets++;
     }
-    
+
     msg->packet_ID = s->packet_counter;
     s->packet_counter++;
     msg->my_N_hop = 0;
@@ -4504,7 +4513,7 @@ static void packet_generate(terminal_state * s, tw_bf * bf, terminal_dally_messa
             terminal_dally_message * m;
             tw_event * e = model_net_method_event_new(lp->gid, bw_ts, lp, DRAGONFLY_DALLY,
                 (void**)&m, NULL);
-            m->type = T_BANDWIDTH; 
+            m->type = T_BANDWIDTH;
             m->magic = terminal_magic_num;
             s->is_monitoring_bw = 1;
             tw_event_send(e);
@@ -4521,19 +4530,19 @@ static void packet_generate(terminal_state * s, tw_bf * bf, terminal_dally_messa
         sizeof(terminal_dally_message_list));
         msg->origin_router_id = s->router_id[msg->rail_id];
         init_terminal_dally_message_list(cur_chunk, msg);
-    
+
         if(msg->remote_event_size_bytes + msg->local_event_size_bytes > 0) {
         cur_chunk->event_data = (char*)calloc(1,
             msg->remote_event_size_bytes + msg->local_event_size_bytes);
         }
-        
+
         void * m_data_src = model_net_method_get_edata(DRAGONFLY_DALLY, msg);
         if (msg->remote_event_size_bytes){
         memcpy(cur_chunk->event_data, m_data_src, msg->remote_event_size_bytes);
         }
-        if (msg->local_event_size_bytes){ 
+        if (msg->local_event_size_bytes){
         m_data_src = (char*)m_data_src + msg->remote_event_size_bytes;
-        memcpy((char*)cur_chunk->event_data + msg->remote_event_size_bytes, 
+        memcpy((char*)cur_chunk->event_data + msg->remote_event_size_bytes,
             m_data_src, msg->local_event_size_bytes);
         }
 
@@ -4544,7 +4553,7 @@ static void packet_generate(terminal_state * s, tw_bf * bf, terminal_dally_messa
         append_to_qlist(&s->terminal_msgs[msg->rail_id][vcg], cur_chunk);
         s->terminal_length[msg->rail_id][vcg] += s->params->chunk_size;
     }
-    
+
     double bandwidth_coef = 1;
     if (g_congestion_control_enabled) {
         if (cc_terminal_is_abatement_active(s->local_congestion_controller)) {
@@ -4616,12 +4625,12 @@ static void packet_generate(terminal_state * s, tw_bf * bf, terminal_dally_messa
     //         s->last_buf_full[msg->rail_id] = tw_now(lp);
     //     }
     // }
-    
+
     if(s->in_send_loop[msg->rail_id] == 0) {
         bf->c5 = 1;
         ts = 0;
         terminal_dally_message *m;
-        tw_event* e = model_net_method_event_new(lp->gid, ts + gen_noise(lp, &msg->num_rngs), lp, DRAGONFLY_DALLY, 
+        tw_event* e = model_net_method_event_new(lp->gid, ts + gen_noise(lp, &msg->num_rngs), lp, DRAGONFLY_DALLY,
         (void**)&m, NULL);
         m->rail_id = msg->rail_id;
         m->type = T_SEND;
@@ -4630,7 +4639,7 @@ static void packet_generate(terminal_state * s, tw_bf * bf, terminal_dally_messa
         tw_event_send(e);
     }
 
-    total_event_size = model_net_get_msg_sz(DRAGONFLY_DALLY) + 
+    total_event_size = model_net_get_msg_sz(DRAGONFLY_DALLY) +
         msg->remote_event_size_bytes + msg->local_event_size_bytes;
     mn_stats* stat;
     stat = model_net_find_stats(msg->category, s->dragonfly_stats_array);
@@ -4652,7 +4661,7 @@ static void packet_send_rc(terminal_state * s, tw_bf * bf, terminal_dally_messag
         s->qos_status[msg->rail_id][0] = Q_ACTIVE;
     if(msg->qos_reset2 && s->params->num_qos_levels > 1)
         s->qos_status[msg->rail_id][1] = Q_ACTIVE;
-    
+
     if(msg->last_saved_qos >= 0)
         s->last_qos_lvl[msg->rail_id] = msg->last_saved_qos;
 
@@ -4661,10 +4670,10 @@ static void packet_send_rc(terminal_state * s, tw_bf * bf, terminal_dally_messag
         s->stalled_chunks[msg->rail_id]--;
         if(bf->c3)
             s->last_buf_full[msg->rail_id] = msg->saved_busy_time;
-    
+
         return;
     }
-    
+
     int vcg = msg->saved_vc;
     s->terminal_available_time[msg->rail_id] = msg->saved_available_time;
 
@@ -4673,10 +4682,10 @@ static void packet_send_rc(terminal_state * s, tw_bf * bf, terminal_dally_messag
     s->vc_occupancy[msg->rail_id][vcg] -= s->params->chunk_size;
     s->link_traffic[msg->rail_id]-=s->params->chunk_size;
     s->total_chunks[msg->rail_id]--;
-    s->injected_chunks--; 
+    s->injected_chunks--;
 
     terminal_dally_message_list* cur_entry = (terminal_dally_message_list *)rc_stack_pop(s->st);
-    
+
     cur_entry->msg.travel_start_time = msg->saved_avg_time;
     int data_size = s->params->chunk_size;
     if(cur_entry->msg.packet_size < s->params->chunk_size)
@@ -4685,7 +4694,7 @@ static void packet_send_rc(terminal_state * s, tw_bf * bf, terminal_dally_messag
     s->qos_data[msg->rail_id][vcg] -= data_size;
 
     prepend_to_qlist(&s->terminal_msgs[msg->rail_id][vcg], cur_entry);
-    
+
     if(bf->c4) {
         s->in_send_loop[msg->rail_id] = msg->saved_send_loop;
     }
@@ -4704,23 +4713,23 @@ static void packet_send_rc(terminal_state * s, tw_bf * bf, terminal_dally_messag
     return;
 }
 /* sends the packet from the current dragonfly compute node to the attached router */
-static void packet_send(terminal_state * s, tw_bf * bf, terminal_dally_message * msg, tw_lp * lp) 
+static void packet_send(terminal_state * s, tw_bf * bf, terminal_dally_message * msg, tw_lp * lp)
 {
-  
+
     tw_stime ts;
     tw_event *e;
     terminal_dally_message *m;
     tw_lpid router_id;
     int vcg = 0;
     int num_qos_levels = s->params->num_qos_levels;
-    
+
     msg->last_saved_qos = -1;
     msg->qos_reset1 = -1;
     msg->qos_reset2 = -1;
     msg->saved_send_loop = s->in_send_loop[msg->rail_id];
 
     vcg = get_next_vcg(s, bf, msg, lp);
-    
+
     /* For a terminal to router connection, there would be as many VCGs as number
     * of VCs*/
 
@@ -4732,7 +4741,7 @@ static void packet_send(terminal_state * s, tw_bf * bf, terminal_dally_message *
         {
             bf->c3 = 1;
             msg->saved_busy_time = s->last_buf_full[msg->rail_id];
-            s->last_buf_full[msg->rail_id] = tw_now(lp); 
+            s->last_buf_full[msg->rail_id] = tw_now(lp);
         }
         return;
     }
@@ -4762,7 +4771,7 @@ static void packet_send(terminal_state * s, tw_bf * bf, terminal_dally_message *
     double bandwidth = s->params->cn_bandwidth;
     if (g_congestion_control_enabled)
         bandwidth = bandwidth_coef * bandwidth;
- 
+
     injection_delay = bytes_to_ns(s->params->chunk_size, bandwidth);
     if((cur_entry->msg.packet_size < s->params->chunk_size) && (cur_entry->msg.chunk_id == num_chunks - 1))
     {
@@ -4772,9 +4781,9 @@ static void packet_send(terminal_state * s, tw_bf * bf, terminal_dally_message *
     propagation_delay = s->params->cn_delay;
 
     s->qos_data[msg->rail_id][vcg] += data_size;
-  
+
     // injection_delay += g_tw_lookahead;
-    
+
     msg->saved_available_time = s->terminal_available_time[msg->rail_id];
     s->terminal_available_time[msg->rail_id] = maxd(s->terminal_available_time[msg->rail_id], tw_now(lp));
     s->terminal_available_time[msg->rail_id] += injection_delay;
@@ -4809,24 +4818,24 @@ static void packet_send(terminal_state * s, tw_bf * bf, terminal_dally_message *
 
 #if DEBUG == 1
     if(cur_entry->msg.packet_ID == LLU(TRACK_PKT) && lp->gid == T_ID)
-        printf("\n Packet %llu generated at terminal %d dest %llu size %llu num chunks %llu router-id %d %llu", 
+        printf("\n Packet %llu generated at terminal %d dest %llu size %llu num chunks %llu router-id %d %llu",
                 cur_entry->msg.packet_ID, s->terminal_id, LLU(cur_entry->msg.dest_terminal_lpid),
                 LLU(cur_entry->msg.packet_size), LLU(num_chunks), s->router_id[msg->rail_id], LLU(router_id));
 #endif
 
-    if(cur_entry->msg.chunk_id == num_chunks - 1 && (cur_entry->msg.local_event_size_bytes > 0)) 
+    if(cur_entry->msg.chunk_id == num_chunks - 1 && (cur_entry->msg.local_event_size_bytes > 0))
     {
         bf->c16 = 1;
         msg->packet_ID = cur_entry->msg.packet_ID;
         tw_stime local_ts = 0;
         tw_event *e_new = tw_event_new(cur_entry->msg.sender_lp, local_ts, lp);
         void * m_new = tw_event_data(e_new);
-        void *local_event = (char*)cur_entry->event_data + 
+        void *local_event = (char*)cur_entry->event_data +
         cur_entry->msg.remote_event_size_bytes;
         memcpy(m_new, local_event, cur_entry->msg.local_event_size_bytes);
         tw_event_send(e_new);
     }
-    
+
     s->vc_occupancy[msg->rail_id][vcg] += s->params->chunk_size;
 
     rc_stack_push(lp, cur_entry, delete_terminal_dally_message_list, s->st);
@@ -4837,7 +4846,7 @@ static void packet_send(terminal_state * s, tw_bf * bf, terminal_dally_message *
 
     int next_vcg = 0;
 
-    if(num_qos_levels > 1) //I think this one is OK since the default is that terminals have only 1 VC anyway so leaving vcg as 
+    if(num_qos_levels > 1) //I think this one is OK since the default is that terminals have only 1 VC anyway so leaving vcg as
         next_vcg = get_next_vcg(s, bf, msg, lp);
 
     /* if there is another packet inline then schedule another send event */
@@ -4861,7 +4870,7 @@ static void packet_send(terminal_state * s, tw_bf * bf, terminal_dally_message *
         bf->c5 = 1;
         s->issueIdle[msg->rail_id] = 0;
         model_net_method_idle_event2(injection_ts, 0, msg->rail_id, lp);
-    
+
         if(s->last_buf_full[msg->rail_id] > 0.0)
         {
             bf->c6 = 1;
@@ -4906,7 +4915,7 @@ static void notify_dest_lp_of(
     new_msg->type        = T_NOTIFY;
     new_msg->notify_type = notification;
     new_msg->magic       = terminal_magic_num;
-    tw_event_send(e); 
+    tw_event_send(e);
 }
 
 static void notify_src_lp_on_total_latency(tw_lp * lp, terminal_dally_message * msg)
@@ -4922,7 +4931,7 @@ static void notify_src_lp_on_total_latency(tw_lp * lp, terminal_dally_message * 
     new_msg->type                    = T_NOTIFY;
     new_msg->notify_type             = NOTIFY_LATENCY;
     new_msg->magic                   = terminal_magic_num;
-    tw_event_send(e); 
+    tw_event_send(e);
 }
 
 static void process_terminal_notification_event_rc(terminal_state * s, tw_bf * bf, terminal_dally_message * msg, tw_lp * lp) {
@@ -4975,7 +4984,7 @@ static void vacuous_msg_to_itself(terminal_state * s, terminal_dally_message * m
 
     new_msg->type  = T_VACUOUS_EVENT;
     new_msg->magic = terminal_magic_num;
-    tw_event_send(e); 
+    tw_event_send(e);
 }
 #endif /* ALWAYS_DETERMINISTIC_NETWORK */
 
@@ -4984,7 +4993,7 @@ static void send_remote_event(terminal_state * s, terminal_dally_message * msg, 
 {
     (void) s;
     void * tmp_ptr = model_net_method_get_edata(DRAGONFLY_DALLY, msg);
-    
+
     tw_stime ts = 0;
 
     if (msg->is_pull){
@@ -4996,7 +5005,7 @@ static void send_remote_event(terminal_state * s, terminal_dally_message * msg, 
         int net_id = model_net_get_id(LP_METHOD_NM_TERM);
 
         model_net_set_msg_param(MN_MSG_PARAM_START_TIME, MN_MSG_PARAM_START_TIME_VAL, &(msg->msg_start_time));
-        
+
         msg->event_rc = model_net_event_mctx(net_id, &mc_src, &mc_dst, msg->category,
                 msg->sender_lp, msg->pull_size, ts + gen_noise(lp, &msg->num_rngs),
                 remote_event_size, tmp_ptr, 0, NULL, lp);
@@ -5005,7 +5014,7 @@ static void send_remote_event(terminal_state * s, terminal_dally_message * msg, 
         tw_event * e = tw_event_new(msg->final_dest_gid, ts, lp);
         void * m_remote = tw_event_data(e);
         memcpy(m_remote, event_data, remote_event_size);
-        tw_event_send(e); 
+        tw_event_send(e);
     }
     return;
 }
@@ -5197,17 +5206,17 @@ static void packet_arrive_rc(terminal_state * s, tw_bf * bf, terminal_dally_mess
     s->ross_sample.fin_chunks_time = msg->saved_sample_time;
     s->fin_chunks_time_ross_sample = msg->saved_fin_chunks_ross;
     s->total_time = msg->saved_avg_time;
-    
+
     struct qhash_head * hash_link = NULL;
-    struct dfly_qhash_entry * tmp = NULL; 
-    
+    struct dfly_qhash_entry * tmp = NULL;
+
     struct dfly_hash_key key;
     key.message_id = msg->message_id;
     key.sender_id = msg->sender_lp;
-    
+
     hash_link = qhash_search(s->rank_tbl, &key);
     tmp = qhash_entry(hash_link, struct dfly_qhash_entry, hash_link);
-    
+
     mn_stats* stat;
     stat = model_net_find_stats(msg->category, s->dragonfly_stats_array);
     stat->recv_time = msg->saved_rcv_time;
@@ -5221,13 +5230,13 @@ static void packet_arrive_rc(terminal_state * s, tw_bf * bf, terminal_dally_mess
         N_finished_packets--;
         s->finished_packets--;
     }
-    
+
     if(bf->c21)
         s->min_latency = msg->saved_min_lat;
     if(bf->c22)
 	{
           s->max_latency = msg->saved_available_time;
-	} 
+	}
 
     struct packet_id const packet_key = {
         .packet_ID = msg->packet_ID,
@@ -5257,7 +5266,7 @@ static void packet_arrive_rc(terminal_state * s, tw_bf * bf, terminal_dally_mess
 
     if(bf->c7) {
         //assert(!hash_link);
-        
+
         N_finished_msgs--;
         s->finished_msgs--;
         total_msg_sz -= msg->total_size;
@@ -5272,16 +5281,16 @@ static void packet_arrive_rc(terminal_state * s, tw_bf * bf, terminal_dally_mess
 
         struct dfly_qhash_entry * d_entry_pop = (dfly_qhash_entry *)rc_stack_pop(s->st);
         qhash_add(s->rank_tbl, &key, &(d_entry_pop->hash_link));
-        s->rank_tbl_pop++; 
-        
+        s->rank_tbl_pop++;
+
         if(s->rank_tbl_pop >= DFLY_HASH_TABLE_SIZE)
             tw_error(TW_LOC, "\n Exceeded allocated qhash size, increase hash size in dragonfly model");
 
         hash_link = &(d_entry_pop->hash_link);
-        tmp = d_entry_pop; 
+        tmp = d_entry_pop;
 
     }
-      
+
     assert(tmp);
     tmp->num_chunks--;
 
@@ -5292,13 +5301,13 @@ static void packet_arrive_rc(terminal_state * s, tw_bf * bf, terminal_dally_mess
     if(bf->c5)
     {
         qhash_del(hash_link);
-        free_tmp(tmp);	
+        free_tmp(tmp);
         s->rank_tbl_pop--;
     }
 }
 
 /* packet arrives at the destination terminal */
-static void packet_arrive(terminal_state * s, tw_bf * bf, terminal_dally_message * msg, tw_lp * lp) 
+static void packet_arrive(terminal_state * s, tw_bf * bf, terminal_dally_message * msg, tw_lp * lp)
 {
     // if(isRoutingMinimal(routing) && msg->my_N_hop > 4)
     // {
@@ -5358,7 +5367,7 @@ static void packet_arrive(terminal_state * s, tw_bf * bf, terminal_dally_message
     uint64_t const num_chunks = num_chunks_for(msg->packet_size, s->params->chunk_size);
 
     if(msg->path_type == MINIMAL)
-        minimal_count++;   
+        minimal_count++;
 
     if(msg->path_type == NON_MINIMAL)
         nonmin_count++;
@@ -5376,7 +5385,7 @@ static void packet_arrive(terminal_state * s, tw_bf * bf, terminal_dally_message
     s->ross_sample.fin_chunks_time += ete_latency;
     msg->saved_fin_chunks_ross = s->fin_chunks_time_ross_sample;
     s->fin_chunks_time_ross_sample += ete_latency;
-    
+
     /* save the total time per LP */
     msg->saved_avg_time = s->total_time;
     s->total_time += ete_latency;
@@ -5405,7 +5414,7 @@ static void packet_arrive(terminal_state * s, tw_bf * bf, terminal_dally_message
     }
 
 #if DEBUG == 1
-    if( msg->packet_ID == TRACK 
+    if( msg->packet_ID == TRACK
             && msg->chunk_id == num_chunks-1
             && msg->message_id == TRACK_MSG)
     {
@@ -5514,14 +5523,14 @@ static void packet_arrive(terminal_state * s, tw_bf * bf, terminal_dally_message
         d_entry->remaining_packets = total_packets;
         qhash_add(s->rank_tbl, &key, &(d_entry->hash_link));
         s->rank_tbl_pop++;
-                
+
         if(s->rank_tbl_pop >= DFLY_HASH_TABLE_SIZE)
                     tw_error(TW_LOC, "\n Exceeded allocated qhash size, increase hash size in dragonfly model");
-        
+
         hash_link = &(d_entry->hash_link);
         tmp = d_entry;
     }
-    
+
     assert(tmp);
     tmp->num_chunks++;
 
@@ -5535,7 +5544,7 @@ static void packet_arrive(terminal_state * s, tw_bf * bf, terminal_dally_message
         /* Retreive the remote event entry */
         tmp->remote_event_data = (char*)calloc(1, msg->remote_event_size_bytes);
         assert(tmp->remote_event_data);
-        tmp->remote_event_size = msg->remote_event_size_bytes; 
+        tmp->remote_event_size = msg->remote_event_size_bytes;
         memcpy(tmp->remote_event_data, m_data_src, msg->remote_event_size_bytes);
     }
 
@@ -5587,8 +5596,8 @@ static void packet_arrive(terminal_state * s, tw_bf * bf, terminal_dally_message
 }
 
 static void terminal_buf_update_rc(terminal_state * s,
-		    tw_bf * bf, 
-		    terminal_dally_message * msg, 
+		    tw_bf * bf,
+		    terminal_dally_message * msg,
 		    tw_lp * lp)
 {
     int vcg = 0;
@@ -5596,7 +5605,7 @@ static void terminal_buf_update_rc(terminal_state * s,
 
     if(num_qos_levels > 1)
         vcg = get_vcg_from_category(msg);
-    
+
     s->vc_occupancy[msg->rail_id][vcg] += s->params->chunk_size;
     if(bf->c1) {
         s->in_send_loop[msg->rail_id] = 0;
@@ -5605,16 +5614,16 @@ static void terminal_buf_update_rc(terminal_state * s,
     return;
 }
 /* update the compute node-router channel buffer */
-static void terminal_buf_update(terminal_state * s, 
-		    tw_bf * bf, 
-		    terminal_dally_message * msg, 
+static void terminal_buf_update(terminal_state * s,
+		    tw_bf * bf,
+		    terminal_dally_message * msg,
 		    tw_lp * lp)
 {
     bf->c1 = 0;
     bf->c2 = 0;
     bf->c3 = 0;
     int vcg = 0;
-        
+
     int num_qos_levels = s->params->num_qos_levels;
 
     if(num_qos_levels > 1)
@@ -5622,11 +5631,11 @@ static void terminal_buf_update(terminal_state * s,
 
     tw_stime ts = 0;
     s->vc_occupancy[msg->rail_id][vcg] -= s->params->chunk_size;
-    
+
     if(s->in_send_loop[msg->rail_id] == 0 && !qlist_empty(&s->terminal_msgs[msg->rail_id][vcg])) {
         terminal_dally_message *m;
         bf->c1 = 1;
-        tw_event* e = model_net_method_event_new(lp->gid, ts + gen_noise(lp, &msg->num_rngs), lp, DRAGONFLY_DALLY, 
+        tw_event* e = model_net_method_event_new(lp->gid, ts + gen_noise(lp, &msg->num_rngs), lp, DRAGONFLY_DALLY,
             (void**)&m, NULL);
         m->rail_id = msg->rail_id;
         m->type = T_SEND;
@@ -5637,7 +5646,7 @@ static void terminal_buf_update(terminal_state * s,
     return;
 }
 
-static void dragonfly_dally_terminal_final( terminal_state * s, 
+static void dragonfly_dally_terminal_final( terminal_state * s,
       tw_lp * lp )
 {
     if (freeze_network_on_switch && is_dally_surrogate_on) {
@@ -5645,14 +5654,14 @@ static void dragonfly_dally_terminal_final( terminal_state * s,
     }
     // printf("terminal id %d\n",s->terminal_id);
     dragonfly_total_time += s->total_time; //increment the PE level time counter
-    
+
     if (s->max_latency > dragonfly_max_latency)
         dragonfly_max_latency = s->max_latency; //get maximum latency across all LPs on this PE
 
 
 	model_net_print_stats(lp->gid, s->dragonfly_stats_array);
     int written = 0;
-  
+
     if(s->terminal_id == 0)
     {
         written += sprintf(s->output_buf + written, "# Format <source_id> <source_type> <dest_id> < dest_type>  <link_type> <link_traffic> <link_saturation> <stalled_chunks>\n");
@@ -5666,8 +5675,8 @@ static void dragonfly_dally_terminal_final( terminal_state * s,
     }
 
 
-    lp_io_write(lp->gid, (char*)"dragonfly-link-stats", written, s->output_buf); 
-    
+    lp_io_write(lp->gid, (char*)"dragonfly-link-stats", written, s->output_buf);
+
     // if(s->terminal_id == 0)
     // {
     //     //fclose(dragonfly_term_bw_log);
@@ -5680,7 +5689,7 @@ static void dragonfly_dally_terminal_final( terminal_state * s,
     //       fprintf(fp, "# Format <LP id> <Terminal ID> <Total Data Size> <Avg packet latency> <# Flits/Packets finished> <Busy Time> <Max packet Latency> <Min packet Latency >\n");
     //     fclose(fp);
     // }
-   
+
     written = 0;
     if(s->terminal_id == 0)
     {
@@ -5693,7 +5702,7 @@ static void dragonfly_dally_terminal_final( terminal_state * s,
     avg_busy_time = avg_busy_time / s->params->num_rails;
 
 
-    written += sprintf(s->output_buf2 + written, "%llu %u %d %llu %lf %lf %lf %ld %lf %lf\n", 
+    written += sprintf(s->output_buf2 + written, "%llu %u %d %llu %lf %lf %lf %ld %lf %lf\n",
             LLU(lp->gid), s->terminal_id, s->total_gen_size, LLU(s->total_msg_size), s->total_time/s->finished_chunks, s->max_latency, s->min_latency,
             s->finished_packets, (double)s->total_hops/s->finished_chunks, avg_busy_time);
 
@@ -5705,7 +5714,7 @@ static void dragonfly_dally_terminal_final( terminal_state * s,
     }
 
 
-    lp_io_write(lp->gid, (char*)"dragonfly-cn-stats", written, s->output_buf2); 
+    lp_io_write(lp->gid, (char*)"dragonfly-cn-stats", written, s->output_buf2);
 
     if (packet_latency_f) {
         // If the last packet transmitted actually received a latency notification (was delievered)
@@ -5753,10 +5762,10 @@ static void dragonfly_dally_terminal_final( terminal_state * s,
 
     //if(s->packet_gen != s->packet_fin)
     //    printf("\n generated %d finished %d ", s->packet_gen, s->packet_fin);
-   
+
     if(s->rank_tbl)
         qhash_finalize(s->rank_tbl);
-    
+
     rc_stack_destroy(s->st);
     rc_stack_destroy(s->cc_st);
     //TODO FREE THESE CORRECTLY
@@ -5788,6 +5797,9 @@ static void dragonfly_dally_terminal_final( terminal_state * s,
     s->sent_packets.~map();
     s->is_pending_local_send.~set();
     s->remaining_sz_packets.~map();
+
+    // TODO: drop once make_lptype<T>() trampoline lands.
+    s->connMan.~DragonflyConnectionManager();
 
     if (s->predictor_data) {
         free(s->predictor_data);
@@ -5827,17 +5839,17 @@ void dragonfly_dally_router_final(router_state * s, tw_lp * lp){
 
     rc_stack_destroy(s->st);
     rc_stack_destroy(s->cc_st);
-    
+
     const dragonfly_param *p = s->params;
     int written = 0;
     int src_rel_id = s->router_id % p->num_routers;
     int local_grp_id = s->router_id / p->num_routers;
-    for(int d = 0; d <= p->intra_grp_radix; d++) 
+    for(int d = 0; d <= p->intra_grp_radix; d++)
     {
         if(d != src_rel_id)
         {
             int dest_ab_id = local_grp_id * p->num_routers + d;
-            written += sprintf(s->output_buf + written, "\n%d %s %d %s %s %llu %lf %lu", 
+            written += sprintf(s->output_buf + written, "\n%d %s %d %s %s %llu %lf %lu",
                 s->router_id,
                 "R",
                 dest_ab_id,
@@ -5893,7 +5905,7 @@ void dragonfly_dally_router_final(router_state * s, tw_lp * lp){
     /*if(!s->router_id)
     {
         written = sprintf(s->output_buf, "# Format <LP ID> <Group ID> <Router ID> <Link Traffic per router port(s)>");
-        written += sprintf(s->output_buf + written, "# Router ports in the order: %d green links, %d black links %d global channels \n", 
+        written += sprintf(s->output_buf + written, "# Router ports in the order: %d green links, %d black links %d global channels \n",
                 p->num_router_cols * p->num_row_chans, p->num_router_rows * p->num_col_chans, p->num_global_channels);
     }
     written += sprintf(s->output_buf2 + written, "\n %llu %d %d",
@@ -5901,14 +5913,14 @@ void dragonfly_dally_router_final(router_state * s, tw_lp * lp){
         s->router_id / p->num_routers,
         s->router_id % p->num_routers);
 
-    for(int d = 0; d < p->radix; d++) 
+    for(int d = 0; d < p->radix; d++)
         written += sprintf(s->output_buf2 + written, " %lld", LLD(s->link_traffic[d]));
 
     lp_io_write(lp->gid, (char*)"dragonfly-router-traffic", written, s->output_buf2);
     */
     // if (!g_tw_mynode) {
     //     if (s->router_id == 0) {
-    //         if (PRINT_CONFIG) 
+    //         if (PRINT_CONFIG)
     //             dragonfly_print_params(s->params);
     //     }
     // }
@@ -5926,7 +5938,7 @@ void dragonfly_dally_router_final(router_state * s, tw_lp * lp){
           for (int d=0; d < p->radix; d++)
               written += sprintf(s->output_buf5 + written, " %d", (s->agg_link_traffic[i][d]));
           lp_io_write(lp->gid, (char*)"dragonfly-router-traffic-sample", written, s->output_buf5);
-      } 
+      }
 
       // for link busy time
       if(!s->router_id){
@@ -5938,9 +5950,11 @@ void dragonfly_dally_router_final(router_state * s, tw_lp * lp){
           for (int d=0; d < p->radix; d++)
               written += sprintf(s->output_buf6 + written, " %lf", (s->agg_busy_time[i][d]));
           lp_io_write(lp->gid, (char*)"dragonfly-router-busytime-sample", written, s->output_buf6);
-      }       
+      }
     }
 
+    // TODO: drop once make_lptype<T>() trampoline lands.
+    s->connMan.~DragonflyConnectionManager();
 }
 
 static Connection do_dfdally_routing(router_state *s, tw_bf *bf, terminal_dally_message *msg, tw_lp *lp, int fdest_router_id)
@@ -5949,7 +5963,7 @@ static Connection do_dfdally_routing(router_state *s, tw_bf *bf, terminal_dally_
     int my_group_id = s->group_id;
     int fdest_group_id = fdest_router_id / s->params->num_routers;
     int origin_group_id = msg->origin_router_id / s->params->num_routers;
-    
+
 
     if (!isRoutingSmart(routing))
     {
@@ -5967,7 +5981,7 @@ static Connection do_dfdally_routing(router_state *s, tw_bf *bf, terminal_dally_
                 vector< Connection > poss_next_stops = s->connMan.get_connections_to_gid(msg->dfdally_dest_terminal_id, CONN_TERMINAL);
                 if (poss_next_stops.size() < 1)
                     tw_error(TW_LOC, "Destination Router %d: No connection to destination terminal %d\n", s->router_id, msg->dfdally_dest_terminal_id); //shouldn't happen unless math was wrong
-                
+
                 Connection best_min_conn = get_absolute_best_connection_from_conns(s, bf, msg, lp, poss_next_stops);
                 return best_min_conn;
             }
@@ -5980,7 +5994,7 @@ static Connection do_dfdally_routing(router_state *s, tw_bf *bf, terminal_dally_
                         tw_error(TW_LOC, "Destination Group %d: No connection to destination router %d\n", s->router_id, fdest_router_id); //shouldn't happen unless the connections weren't set up / loaded correctly
                     conns_to_fdest = poss_next_stops;
                 }
-                    
+
 
                 if (isRoutingAdaptive(routing)) { // Pick the best connection
                     Connection best_conn = get_absolute_best_connection_from_conns(s, bf, msg, lp, conns_to_fdest);
@@ -6010,7 +6024,7 @@ static Connection do_dfdally_routing(router_state *s, tw_bf *bf, terminal_dally_
             next_stop_conn = dfdally_minimal_routing(s, bf, msg, lp, fdest_router_id);
             break;
         case NON_MINIMAL:
-            msg->path_type = NON_MINIMAL;            
+            msg->path_type = NON_MINIMAL;
             next_stop_conn = dfdally_nonminimal_routing(s, bf, msg, lp, fdest_router_id);
             break;
         case ADAPTIVE:
@@ -6066,7 +6080,7 @@ static void router_verify_valid_receipt(router_state *s, tw_bf *bf, terminal_dal
         if (!has_valid_connection) {
             tw_error(TW_LOC, "\nRouter received packet from non-existent connection - Terminal\n");
         }
-    
+
     }
     else if (msg->last_hop == LOCAL)
     {
@@ -6093,11 +6107,11 @@ static void router_verify_valid_receipt(router_state *s, tw_bf *bf, terminal_dal
     else {
         tw_error(TW_LOC, "\nUnspecified msg->last_hop when received by a router\n");
     }
-    
+
 }
 
 /*When a packet is sent from the current router and a buffer slot becomes available, a credit is sent back to schedule another packet event*/
-static void router_credit_send(router_state * s, terminal_dally_message * msg, 
+static void router_credit_send(router_state * s, terminal_dally_message * msg,
   tw_lp * lp, int sq, short* rng_counter) {
     tw_event * buf_e;
     tw_stime ts;
@@ -6108,14 +6122,14 @@ static void router_credit_send(router_state * s, terminal_dally_message * msg,
     double credit_delay;
 
     const dragonfly_param *p = s->params;
-    
+
     // Notify sender terminal about available buffer space
     if(msg->last_hop == TERMINAL) {
         dest = msg->src_terminal_id;
         type = T_BUFFER;
         is_terminal = 1;
         credit_delay = p->cn_credit_delay;
-    } 
+    }
     else if(msg->last_hop == GLOBAL) {
         dest = msg->intm_lp_id;
         credit_delay = p->global_credit_delay;
@@ -6123,7 +6137,7 @@ static void router_credit_send(router_state * s, terminal_dally_message * msg,
     else if(msg->last_hop == LOCAL) {
         dest = msg->intm_lp_id;
         credit_delay = p->local_credit_delay;
-    } 
+    }
     else
         printf("\n Invalid message type");
 
@@ -6134,16 +6148,16 @@ static void router_credit_send(router_state * s, terminal_dally_message * msg,
     ts = credit_delay;
 
     if (is_terminal) {
-        buf_e = model_net_method_event_new(dest, ts + gen_noise(lp, &msg->num_rngs), lp, DRAGONFLY_DALLY, 
+        buf_e = model_net_method_event_new(dest, ts + gen_noise(lp, &msg->num_rngs), lp, DRAGONFLY_DALLY,
         (void**)&buf_msg, NULL);
         buf_msg->magic = terminal_magic_num;
-    } 
+    }
     else {
         buf_e = model_net_method_event_new(dest, ts + gen_noise(lp, &msg->num_rngs), lp, DRAGONFLY_DALLY_ROUTER,
                 (void**)&buf_msg, NULL);
         buf_msg->magic = router_magic_num;
     }
-    
+
     buf_msg->rail_id = msg->rail_id;
     buf_msg->origin_router_id = s->router_id;
     if(sq == -1) {
@@ -6153,7 +6167,7 @@ static void router_credit_send(router_state * s, terminal_dally_message * msg,
         buf_msg->vc_index = msg->saved_vc;
         buf_msg->output_chan = msg->saved_channel;
     }
-    strcpy(buf_msg->category, msg->category); 
+    strcpy(buf_msg->category, msg->category);
     buf_msg->type = type;
 
     tw_event_send(buf_e);
@@ -6164,7 +6178,7 @@ static void router_packet_receive_rc(router_state * s,
         tw_bf * bf,
         terminal_dally_message * msg,
         tw_lp * lp)
-{  
+{
     int output_port = msg->saved_vc;
     int output_chan = msg->saved_channel;
     int src_term_id = msg->dfdally_src_terminal_id;
@@ -6197,7 +6211,7 @@ static void router_packet_receive_rc(router_state * s,
         terminal_dally_message_list *tail = qlist_entry(last, terminal_dally_message_list, list);
         delete_terminal_dally_message_list(tail);
     }
-    s->queued_count[output_port] -= s->params->chunk_size; 
+    s->queued_count[output_port] -= s->params->chunk_size;
     }
 
     if (g_congestion_control_enabled) {
@@ -6208,9 +6222,9 @@ static void router_packet_receive_rc(router_state * s,
 }
 
 /* Packet arrives at the router and a credit is sent back to the sending terminal/router */
-static void router_packet_receive( router_state * s, 
-			tw_bf * bf, 
-			terminal_dally_message * msg, 
+static void router_packet_receive( router_state * s,
+			tw_bf * bf,
+			terminal_dally_message * msg,
 			tw_lp * lp )
 {
     router_verify_valid_receipt(s, bf, msg, lp);
@@ -6227,9 +6241,9 @@ static void router_packet_receive( router_state * s,
             bf->c1 = 1;
             tw_stime bw_ts = bw_reset_window;
             terminal_dally_message * m;
-            tw_event * e = model_net_method_event_new(lp->gid, bw_ts + gen_noise(lp, &msg->num_rngs), lp, 
-                DRAGONFLY_DALLY_ROUTER, (void**)&m, NULL); 
-            m->type = R_BANDWIDTH; 
+            tw_event * e = model_net_method_event_new(lp->gid, bw_ts + gen_noise(lp, &msg->num_rngs), lp,
+                DRAGONFLY_DALLY_ROUTER, (void**)&m, NULL);
+            m->type = R_BANDWIDTH;
             m->magic = router_magic_num;
             tw_event_send(e);
             s->is_monitoring_bw = 1;
@@ -6250,7 +6264,7 @@ static void router_packet_receive( router_state * s,
     msg->this_router_arrival = tw_now(lp);
     terminal_dally_message_list * cur_chunk = (terminal_dally_message_list*)calloc(1, sizeof(terminal_dally_message_list));
     init_terminal_dally_message_list(cur_chunk, msg);
-    
+
     if(cur_chunk->msg.last_hop == TERMINAL) // We are first router in the path
         cur_chunk->msg.path_type = MINIMAL; // Route always starts as minimal
 
@@ -6343,7 +6357,7 @@ static void router_packet_receive( router_state * s,
     //     cur_chunk->msg.my_hops_cur_group = 0; //reset this as it's going to a new group
     //     cur_chunk->msg.my_g_hop++;
     // }
-        
+
     assert(output_chan < vcs_per_qos);
     output_chan = output_chan + (vcg * vcs_per_qos);
     assert(output_chan < s->params->num_vcs && output_chan >= 0);
@@ -6353,7 +6367,7 @@ static void router_packet_receive( router_state * s,
 
     if(output_port >= s->params->radix)
         tw_error(TW_LOC, "\n Output port greater than router radix %d ", output_port);
-    
+
     if(output_chan >= s->params->num_vcs || output_chan < 0)
         tw_error(TW_LOC, "\n Output channel %d great than available VCs %d", output_chan, s->params->num_vcs - 1);
                 //cur_chunk->msg.packet_ID, output_chan, output_port, s->router_id, dest_router_id, cur_chunk->msg.path_type, src_grp_id, dest_grp_id, msg->src_terminal_id);
@@ -6373,7 +6387,7 @@ static void router_packet_receive( router_state * s,
         bf->c2 = 1;
         assert(output_chan < s->params->num_vcs && output_port < s->params->radix);
         router_credit_send(s, msg, lp, -1, &(msg->num_rngs));
-    
+
         qlist_add_tail(&cur_chunk->list, &s->pending_msgs[output_port][output_chan]);
         s->vc_occupancy[output_port][output_chan] += s->params->chunk_size;
         if(s->in_send_loop[output_port] == 0) {
@@ -6386,12 +6400,12 @@ static void router_packet_receive( router_state * s,
             m->type = R_SEND;
             m->magic = router_magic_num;
             m->vc_index = output_port;
-            
+
             tw_event_send(e);
             s->in_send_loop[output_port] = 1;
         }
-    } 
-    else 
+    }
+    else
     {
         bf->c4 = 1;
         s->stalled_chunks[output_port]++;
@@ -6431,19 +6445,19 @@ static void router_packet_receive( router_state * s,
 static void router_packet_send_rc(router_state * s, tw_bf * bf, terminal_dally_message * msg, tw_lp * lp)
 {
     int num_qos_levels = s->params->num_qos_levels;
-   
+
     int output_port = msg->saved_vc;
     int src_term_id = msg->dfdally_src_terminal_id;
     int app_id = msg->saved_app_id;
-      
+
     assert(output_port < s->params->radix);
     if(msg->qos_reset1)
         s->qos_status[output_port][0] = Q_ACTIVE;
     if(msg->qos_reset2 && s->params->num_qos_levels > 1)
         s->qos_status[output_port][1] = Q_ACTIVE;
-    
+
     if(msg->last_saved_qos)
-       s->last_qos_lvl[output_port] = msg->last_saved_qos; 
+       s->last_qos_lvl[output_port] = msg->last_saved_qos;
 
     //Xin: target window to rollback
     bool rolback = false;
@@ -6454,14 +6468,14 @@ static void router_packet_send_rc(router_state * s, tw_bf * bf, terminal_dally_m
         if(current_window < s->params->counting_windows) {
           rolback = true;
         }
-    }      
+    }
 
     if(bf->c1) {
         s->in_send_loop[output_port] = msg->saved_send_loop;
         if(bf->c2) {
             s->last_buf_full[output_port] = msg->saved_busy_time;
         }
-        return;  
+        return;
     }
     s->last_qos_lvl[output_port] = msg->last_saved_qos;
 
@@ -6478,10 +6492,10 @@ static void router_packet_send_rc(router_state * s, tw_bf * bf, terminal_dally_m
           s->agg_busy_time[current_window][output_port] = msg->saved_rcv_time;
         }
     }
-      
+
     terminal_dally_message_list * cur_entry = (terminal_dally_message_list *)rc_stack_pop(s->st);
     assert(cur_entry);
- 
+
     int vcg = 0;
     if(num_qos_levels > 1)
         vcg = get_vcg_from_category(&(cur_entry->msg));
@@ -6495,9 +6509,9 @@ static void router_packet_send_rc(router_state * s, tw_bf * bf, terminal_dally_m
     if(bf->c11)
     {
         s->link_traffic[output_port] -= cur_entry->msg.packet_size % s->params->chunk_size;
-        s->link_traffic_sample[output_port] -= cur_entry->msg.packet_size % s->params->chunk_size; 
-        s->ross_rsample.link_traffic_sample[output_port] -= cur_entry->msg.packet_size % s->params->chunk_size; 
-        s->link_traffic_ross_sample[output_port] -= cur_entry->msg.packet_size % s->params->chunk_size; 
+        s->link_traffic_sample[output_port] -= cur_entry->msg.packet_size % s->params->chunk_size;
+        s->ross_rsample.link_traffic_sample[output_port] -= cur_entry->msg.packet_size % s->params->chunk_size;
+        s->link_traffic_ross_sample[output_port] -= cur_entry->msg.packet_size % s->params->chunk_size;
         msg_size = cur_entry->msg.packet_size % s->params->chunk_size;
 
         //Xin: reverse link traffic
@@ -6550,11 +6564,11 @@ static void router_packet_send( router_state * s, tw_bf * bf, terminal_dally_mes
 
     int num_qos_levels = s->params->num_qos_levels;
     int output_chan = get_next_router_vcg(s, bf, msg, lp); //includes default output_chan setting functionality if qos not enabled
-    
+
     msg->saved_vc = output_port;
     msg->saved_channel = output_chan;
 
-    //Xin: target window to update link traffic 
+    //Xin: target window to update link traffic
     msg->last_sent_time = tw_now(lp);
     bool update = false;
     int current_window = -1;
@@ -6565,14 +6579,14 @@ static void router_packet_send( router_state * s, tw_bf * bf, terminal_dally_mes
           update = true;
         }
     }
-    
-    if(output_chan < 0) 
+
+    if(output_chan < 0)
     {
         bf->c1 = 1;
         s->in_send_loop[output_port] = 0;
         if(s->queued_count[output_port] && !s->last_buf_full[output_port])  //5-21-19, not sure why this was added here with the qos stuff
         {
-            bf->c2 = 1; 
+            bf->c2 = 1;
             msg->saved_busy_time = s->last_buf_full[output_port];
             s->last_buf_full[output_port] = tw_now(lp);
         }
@@ -6585,7 +6599,7 @@ static void router_packet_send( router_state * s, tw_bf * bf, terminal_dally_mes
     } else {
         cur_entry = NULL;
     }
-    
+
     msg->dfdally_src_terminal_id = cur_entry->msg.dfdally_src_terminal_id;
 
     assert(cur_entry != NULL);
@@ -6593,24 +6607,24 @@ static void router_packet_send( router_state * s, tw_bf * bf, terminal_dally_mes
     if(s->last_buf_full[output_port]) //5-12-19, same here as above comment
     {
         bf->c8 = 1;
-        msg->saved_rcv_time = s->busy_time[output_port]; 
-        msg->saved_busy_time = s->last_buf_full[output_port]; 
-        msg->saved_sample_time = s->busy_time_sample[output_port];  
-        s->busy_time[output_port] += (tw_now(lp) - s->last_buf_full[output_port]); 
+        msg->saved_rcv_time = s->busy_time[output_port];
+        msg->saved_busy_time = s->last_buf_full[output_port];
+        msg->saved_sample_time = s->busy_time_sample[output_port];
+        s->busy_time[output_port] += (tw_now(lp) - s->last_buf_full[output_port]);
         s->busy_time_sample[output_port] += (tw_now(lp) - s->last_buf_full[output_port]);
         s->ross_rsample.busy_time[output_port] += (tw_now(lp) - s->last_buf_full[output_port]);
         s->last_buf_full[output_port] = 0.0;
 
         //Xin: update link busy time
         if(update && current_window >= 0){
-            s->agg_busy_time[current_window][output_port] += (tw_now(lp) - s->last_buf_full[output_port]); 
+            s->agg_busy_time[current_window][output_port] += (tw_now(lp) - s->last_buf_full[output_port]);
         }
     }
 
     int vcg = 0;
     if(num_qos_levels > 1)
         vcg = get_vcg_from_category(&(cur_entry->msg));
-        
+
     int to_terminal = 1, global = 0;
     double delay = s->params->cn_delay;
     double bandwidth = s->params->cn_bandwidth;
@@ -6619,8 +6633,8 @@ static void router_packet_send( router_state * s, tw_bf * bf, terminal_dally_mes
         to_terminal = 0;
         delay = s->params->local_delay;
         bandwidth = s->params->local_bandwidth;
-    } 
-    else if(output_port < s->params->intra_grp_radix + 
+    }
+    else if(output_port < s->params->intra_grp_radix +
             s->params->num_global_channels) {
         to_terminal = 0;
         global = 1;
@@ -6650,7 +6664,7 @@ static void router_packet_send( router_state * s, tw_bf * bf, terminal_dally_mes
     injection_delay += s->params->router_delay;
 
     msg->saved_available_time = s->next_output_available_time[output_port];
-    s->next_output_available_time[output_port] = 
+    s->next_output_available_time[output_port] =
         maxd(s->next_output_available_time[output_port], tw_now(lp));
     s->next_output_available_time[output_port] += injection_delay;
 
@@ -6667,7 +6681,7 @@ static void router_packet_send( router_state * s, tw_bf * bf, terminal_dally_mes
         if(cur_entry->msg.next_stop != cur_entry->msg.dest_terminal_lpid)
         printf("\n intra-group radix %d output port %d next stop %d", s->params->intra_grp_radix, output_port, cur_entry->msg.next_stop);
         assert(cur_entry->msg.next_stop == cur_entry->msg.dest_terminal_lpid);
-        e = model_net_method_event_new(cur_entry->msg.next_stop, 
+        e = model_net_method_event_new(cur_entry->msg.next_stop,
             propagation_ts + gen_noise(lp, &msg->num_rngs), lp, DRAGONFLY_DALLY, (void**)&m, &m_data);
     }
     else {
@@ -6690,7 +6704,7 @@ static void router_packet_send( router_state * s, tw_bf * bf, terminal_dally_mes
     int msg_size = s->params->chunk_size;
     if(((cur_entry->msg.packet_size % s->params->chunk_size) || cur_entry->msg.packet_size == 0) && (cur_entry->msg.chunk_id == num_chunks - 1)) {
         bf->c11 = 1;
-        s->link_traffic[output_port] +=  (cur_entry->msg.packet_size % s->params->chunk_size); 
+        s->link_traffic[output_port] +=  (cur_entry->msg.packet_size % s->params->chunk_size);
         s->link_traffic_sample[output_port] += (cur_entry->msg.packet_size % s->params->chunk_size);
         s->ross_rsample.link_traffic_sample[output_port] += (cur_entry->msg.packet_size % s->params->chunk_size);
         s->link_traffic_ross_sample[output_port] += (cur_entry->msg.packet_size % s->params->chunk_size);
@@ -6698,9 +6712,9 @@ static void router_packet_send( router_state * s, tw_bf * bf, terminal_dally_mes
 
         //Xin: update link traffic
         if(update && current_window >= 0){
-            s->agg_link_traffic[current_window][output_port] += (cur_entry->msg.packet_size % s->params->chunk_size);           
+            s->agg_link_traffic[current_window][output_port] += (cur_entry->msg.packet_size % s->params->chunk_size);
         }
-    } 
+    }
     else {
         bf->c12 = 1;
         s->link_traffic[output_port] += s->params->chunk_size;
@@ -6708,7 +6722,7 @@ static void router_packet_send( router_state * s, tw_bf * bf, terminal_dally_mes
         s->ross_rsample.link_traffic_sample[output_port] += s->params->chunk_size;
         s->link_traffic_ross_sample[output_port] += s->params->chunk_size;
 
-        //Xin: update link traffic 
+        //Xin: update link traffic
         if(update && current_window >= 0){
             s->agg_link_traffic[current_window][output_port] += s->params->chunk_size;
         }
@@ -6723,8 +6737,8 @@ static void router_packet_send( router_state * s, tw_bf * bf, terminal_dally_mes
 
     m->rail_id = msg->rail_id;
 
-    /* Determine the event type. If the packet has arrived at the final 
-    * destination router then it should arrive at the destination terminal 
+    /* Determine the event type. If the packet has arrived at the final
+    * destination router then it should arrive at the destination terminal
     * next.*/
     if(to_terminal) {
         m->type = T_ARRIVE;
@@ -6747,7 +6761,7 @@ static void router_packet_send( router_state * s, tw_bf * bf, terminal_dally_mes
     cur_entry = item ? qlist_entry(item, terminal_dally_message_list, list) : NULL;
     rc_stack_push(lp, cur_entry, delete_terminal_dally_message_list, s->st);
 
-    s->qos_data[output_port][vcg] += msg_size; 
+    s->qos_data[output_port][vcg] += msg_size;
     s->next_output_available_time[output_port] -= s->params->router_delay;
     injection_ts -= s->params->router_delay;
 
@@ -6781,7 +6795,7 @@ static void router_packet_send( router_state * s, tw_bf * bf, terminal_dally_mes
     } else {
         cur_entry = NULL;
     }
-    assert(cur_entry != NULL); 
+    assert(cur_entry != NULL);
 
     terminal_dally_message *m_new;
     e = model_net_method_event_new(lp->gid, injection_ts + gen_noise(lp, &msg->num_rngs), lp, DRAGONFLY_DALLY_ROUTER,
@@ -6882,10 +6896,10 @@ static void router_buf_update(router_state * s, tw_bf * bf, terminal_dally_messa
                 tw_error(TW_LOC, "\n invalid output chan %d last-hop %d", head->msg.saved_channel, head->msg.last_hop);
         }
         }*/
-        router_credit_send(s, &head->msg, lp, 1, &(msg->num_rngs)); 
+        router_credit_send(s, &head->msg, lp, 1, &(msg->num_rngs));
         qlist_add_tail(&head->list, &s->pending_msgs[indx][output_chan]);
         s->vc_occupancy[indx][output_chan] += s->params->chunk_size;
-        s->queued_count[indx] -= s->params->chunk_size; 
+        s->queued_count[indx] -= s->params->chunk_size;
     }
 
     if(s->in_send_loop[indx] == 0 && !qlist_empty(&s->pending_msgs[indx][output_chan])) {
@@ -6904,10 +6918,10 @@ static void router_buf_update(router_state * s, tw_bf * bf, terminal_dally_messa
     return;
 }
 
-static void 
-terminal_dally_event( terminal_state * s, 
-		tw_bf * bf, 
-		terminal_dally_message * msg, 
+static void
+terminal_dally_event( terminal_state * s,
+		tw_bf * bf,
+		terminal_dally_message * msg,
 		tw_lp * lp )
 {
     msg->num_cll = 0;
@@ -6941,7 +6955,7 @@ terminal_dally_event( terminal_state * s,
                 packet_generate(s,bf,msg,lp);
             }
         break;
-        
+
         case T_ARRIVE:
             packet_arrive(s,bf,msg,lp);
         break;
@@ -6949,19 +6963,19 @@ terminal_dally_event( terminal_state * s,
         case T_ARRIVE_PREDICTED:
             packet_arrive_predicted(s,bf,msg,lp);
         break;
-        
+
         case T_SEND:
             packet_send(s,bf,msg,lp);
         break;
-        
+
         case T_BUFFER:
             terminal_buf_update(s, bf, msg, lp);
         break;
-    
+
         case T_BANDWIDTH:
             issue_bw_monitor_event(s, bf, msg, lp);
         break;
-    
+
         case T_NOTIFY:
             process_terminal_notification_event(s, bf, msg, lp);
         break;
@@ -6977,8 +6991,8 @@ terminal_dally_event( terminal_state * s,
         }
 }
 
-static void router_dally_event(router_state * s, tw_bf * bf, terminal_dally_message * msg, 
-    tw_lp * lp) 
+static void router_dally_event(router_state * s, tw_bf * bf, terminal_dally_message * msg,
+    tw_lp * lp)
 {
     msg->num_cll = 0;
     msg->num_rngs = 0;
@@ -6990,7 +7004,7 @@ static void router_dally_event(router_state * s, tw_bf * bf, terminal_dally_mess
 
     msg->last_received_time = s->last_time;
     s->last_time = tw_now(lp);
-    
+
     assert(msg->magic == router_magic_num);
     switch(msg->type)
     {
@@ -7017,18 +7031,18 @@ static void router_dally_event(router_state * s, tw_bf * bf, terminal_dally_mess
         case R_SNAPSHOT:
             router_handle_snapshot_event(s, bf, msg, lp);
         break;
-        
+
         default:
-            printf("\n (%lf) [Router %d] Router Message type not supported %d dest " 
-                "terminal id %d packet ID %d ", tw_now(lp), (int)lp->gid, msg->type, 
+            printf("\n (%lf) [Router %d] Router Message type not supported %d dest "
+                "terminal id %d packet ID %d ", tw_now(lp), (int)lp->gid, msg->type,
                 (int)msg->dest_terminal_lpid, (int)msg->packet_ID);
             tw_error(TW_LOC, "Msg type not supported");
         break;
-    }	   
+    }
 }
 
 /* Reverse computation handler for a terminal event */
-static void terminal_dally_rc_event_handler(terminal_state * s, tw_bf * bf, terminal_dally_message * msg, tw_lp * lp) 
+static void terminal_dally_rc_event_handler(terminal_state * s, tw_bf * bf, terminal_dally_message * msg, tw_lp * lp)
 {
     s->rev_events++;
     s->ross_sample.rev_events++;
@@ -7052,7 +7066,7 @@ static void terminal_dally_rc_event_handler(terminal_state * s, tw_bf * bf, term
             if (bf->c10) {
                 packet_generate_predicted_rc(s,bf,msg,lp);
             } else {
-                packet_generate_rc(s, bf, msg, lp); 
+                packet_generate_rc(s, bf, msg, lp);
             }
             break;
 
@@ -7069,13 +7083,13 @@ static void terminal_dally_rc_event_handler(terminal_state * s, tw_bf * bf, term
             break;
 
         case T_BUFFER:
-            terminal_buf_update_rc(s, bf, msg, lp); 
+            terminal_buf_update_rc(s, bf, msg, lp);
             break;
 
         case T_BANDWIDTH:
             issue_bw_monitor_event_rc(s,bf, msg, lp);
             break;
-    
+
         case T_NOTIFY:
             process_terminal_notification_event_rc(s, bf, msg, lp);
         break;
@@ -7094,8 +7108,8 @@ static void terminal_dally_rc_event_handler(terminal_state * s, tw_bf * bf, term
 }
 
 /* Reverse computation handler for a router event */
-static void router_dally_rc_event_handler(router_state * s, tw_bf * bf, 
-  terminal_dally_message * msg, tw_lp * lp) 
+static void router_dally_rc_event_handler(router_state * s, tw_bf * bf,
+  terminal_dally_message * msg, tw_lp * lp)
 {
     s->last_time = msg->last_received_time;
 
@@ -7109,17 +7123,17 @@ static void router_dally_rc_event_handler(router_state * s, tw_bf * bf,
     s->ross_rsample.rev_events++;
 
     switch((enum event_t) msg->type) {
-        case R_SEND: 
+        case R_SEND:
             router_packet_send_rc(s, bf, msg, lp);
         break;
-        case R_ARRIVE: 
+        case R_ARRIVE:
             router_packet_receive_rc(s, bf, msg, lp);
         break;
 
-        case R_BUFFER: 
+        case R_BUFFER:
             router_buf_update_rc(s, bf, msg, lp);
         break;
-        
+
         case R_BANDWIDTH:
             issue_rtr_bw_monitor_event_rc(s, bf, msg, lp);
         break;
@@ -8484,7 +8498,7 @@ static vector< Connection > get_legal_minimal_stops(router_state *s, tw_bf *bf, 
         }
         // else { //we don't have a direct connection to group and need list of routers in our group that do
         //     return s->connMan.get_routed_connections_to_group(fdest_group_id, true); //get list of connections that I have that go to a router in my group that go to dest group
-        //     // --------- return non-direct connection (still minimal though)        
+        //     // --------- return non-direct connection (still minimal though)
         // }
         else { //we don't have a direct connection to group and need list of routers in our group that do
             vector<Connection> poss_next_conns_to_group = s->connMan.get_routed_connections_to_group(fdest_group_id, true);
@@ -8500,7 +8514,7 @@ static vector< Connection > get_legal_minimal_stops(router_state *s, tw_bf *bf, 
             //         poss_next_conns_to_group.insert(poss_next_conns_to_group.end(), conns.begin(), conns.end());
             //     }
             // }
-            return poss_next_conns_to_group; 
+            return poss_next_conns_to_group;
         }
     }
     else { //then we're in the final destination group, also we assume that we're not the fdest router
@@ -8621,7 +8635,7 @@ static Connection dfdally_nonminimal_routing(router_state *s, tw_bf *bf, termina
     assert(msg->intm_grp_id != -1); // This needs to have already been set.
     // //The setting of intm_grp_id is kept out of this function so that other routing algorithms can utilize this routing function
     // //and set it themselves based on the context. This helps avoid an instance like: prog-adaptive routing, second router in path decides
-    // //to take non-minimal routing but the pre-selected intermediate group ID isn't accessible to it and would require re-routing and 
+    // //to take non-minimal routing but the pre-selected intermediate group ID isn't accessible to it and would require re-routing and
     // //thus take extra hops. Possible illegal move and could cause deadlock.
 
     if (my_group_id == msg->intm_grp_id) //then we've visited the intermediate group by definition
@@ -8655,11 +8669,11 @@ static Connection dfdally_nonminimal_routing(router_state *s, tw_bf *bf, termina
         // msg->num_rngs++;
         // rand_sel = tw_rand_integer(lp->rng, 0, conns_to_next_router.size()-1);
         // Connection next_conn = conns_to_next_router[rand_sel];
-        
+
         int rand_sel = tw_rand_integer(lp->rng, 0, connections_toward_next_group.size()-1);
         msg->num_rngs++;
         Connection next_conn = connections_toward_next_group[rand_sel];
-        
+
         return next_conn;
     }
 }
@@ -8672,7 +8686,7 @@ static Connection dfdally_prog_adaptive_routing(router_state *s, tw_bf *bf, term
     int fdest_group_id = fdest_router_id / s->params->num_routers;
     int origin_group_id = msg->origin_router_id / s->params->num_routers;
     int adaptive_threshold = s->params->adaptive_threshold;
-    
+
     // The check for detination group local routing has already been completed - we can assume we're not in the destination group
 
     // are we in the intermediate group?
@@ -8699,7 +8713,7 @@ static Connection dfdally_prog_adaptive_routing(router_state *s, tw_bf *bf, term
         best_min_conn = dfdally_get_best_from_k_connections(s, bf, msg, lp, poss_min_next_stops, s->params->global_k_picks);
     else
         best_min_conn = get_absolute_best_connection_from_conns(s, bf, msg, lp, poss_min_next_stops); //could use from_k_connections function but that's very expensive when k == size of input connections
-    
+
     if (conn_type_of_nonmins == CONN_GLOBAL)
         best_nonmin_conn = dfdally_get_best_from_k_connections(s, bf, msg, lp, poss_nonmin_next_stops, s->params->global_k_picks);
     else
@@ -8745,14 +8759,14 @@ static set< Connection> get_smart_legal_minimal_stops(router_state *s, tw_bf *bf
     }
     // vector<int> shortest_path_next_gids = netMan.get_shortest_nexts(s->router_id, fdest_router_id);
     // for(vector<int>::iterator it = shortest_path_next_gids.begin(); it != shortest_path_next_gids.end(); it++)
-    // {   
+    // {
     //     vector<Connection> local_conns;
     //     vector<Connection> global_conns;
     //     if(msg->my_hops_cur_group < max_hops_per_group)
     //         local_conns = s->connMan.get_connections_to_gid(*it,CONN_LOCAL);
     //     if(msg->my_g_hop < max_global_hops_in_path)
     //         global_conns = s->connMan.get_connections_to_gid(*it,CONN_GLOBAL);
-        
+
     //     vector<Connection>::iterator it2;
     //     for(it2 = local_conns.begin(); it2 != local_conns.end(); it2++)
     //     {
@@ -8841,7 +8855,7 @@ static Connection dfdally_smart_minimal_routing(router_state *s, tw_bf *bf, term
         set<Connection>::iterator it = possible_conns.begin();
         advance(it, offset);
         return *(it);
-    }    
+    }
 }
 
 static Connection dfdally_smart_nonminimal_routing(router_state *s, tw_bf *bf, terminal_dally_message *msg, tw_lp *lp, int fdest_router_id)
@@ -8859,10 +8873,10 @@ static Connection dfdally_smart_nonminimal_routing(router_state *s, tw_bf *bf, t
         Connection best_conn = get_absolute_best_connection_from_conns(s, bf, msg, lp, poss_next_stops);
         return best_conn;
     }
-    
+
     if (my_group_id != origin_group_id && my_group_id != fdest_group_id)
         msg->path_type = NON_MINIMAL;
-        
+
     set<Connection> possible_conns = get_smart_legal_nonminimal_stops(s, bf, msg, lp, fdest_router_id);
 
     if (possible_conns.size() < 1)
@@ -8933,7 +8947,7 @@ static Connection dfdally_smart_prog_adaptive_routing(router_state *s, tw_bf *bf
                     msg->path_type = NON_MINIMAL;
                     return best_nonmin_conn;
                 }
-            } else 
+            } else
             {
                 set<Connection> poss_min_next_stops = get_smart_legal_minimal_stops(s, bf, msg, lp, fdest_router_id, max_global_hops_nonminimal);
                 return dfdally_get_best_from_k_connection_set(s, bf, msg, lp, poss_min_next_stops,s->params->global_k_picks);
@@ -8979,7 +8993,7 @@ static int get_port_score_legacy(router_state * s,
 
     if(port <= 0)
        return INT_MAX;
-    
+
     for(int k = 0; k < s->params->num_vcs; k++)
     {
         port_count += s->vc_occupancy[port][k];
@@ -9001,10 +9015,10 @@ static void do_local_adaptive_routing_legacy(router_state * s,
         short* rng_counter)
 {
 
-        //this is an adaptation of the do_local_adaptive_routing() from the original dragonfly-dally model found below   
+        //this is an adaptation of the do_local_adaptive_routing() from the original dragonfly-dally model found below
         int next_min_stop = dest_router_id; //was a vector of one in original - this is equivalent to what it did
         int next_nonmin_stop = intm_router_id; //was a vector of one
-        
+
         Connection min_conn = s->connMan.get_connections_to_gid(next_min_stop, CONN_LOCAL)[0];
         Connection nonmin_conn = s->connMan.get_connections_to_gid(next_nonmin_stop, CONN_LOCAL)[0];
 
@@ -9017,9 +9031,9 @@ static void do_local_adaptive_routing_legacy(router_state * s,
         }
         else
             msg->path_type = MINIMAL;
-        
+
 // Old version
-//     tw_lpid min_rtr_id, nonmin_rtr_id; 
+//     tw_lpid min_rtr_id, nonmin_rtr_id;
 //     int min_port, nonmin_port;
 
 //     int dest_grp_id = dest_router_id / s->params->num_routers;
@@ -9038,7 +9052,7 @@ static void do_local_adaptive_routing_legacy(router_state * s,
 //     min_chan = tw_rand_integer(lp->rng, 0, next_min_stops.size() - 1);
 //     (*rng_counter)++;
 //     nonmin_chan = tw_rand_integer(lp->rng, 0, next_nonmin_stops.size() - 1);
-  
+
 //     codes_mapping_get_lp_id(lp_group_name, LP_CONFIG_NM_ROUT, s->anno, 0, next_min_stops[min_chan] / num_routers_per_mgrp,
 //           next_min_stops[min_chan] % num_routers_per_mgrp, &min_rtr_id);
 //     codes_mapping_get_lp_id(lp_group_name, LP_CONFIG_NM_ROUT, s->anno, 0, next_nonmin_stops[nonmin_chan] / num_routers_per_mgrp,
@@ -9082,7 +9096,7 @@ static int get_output_port_legacy(router_state *s, terminal_dally_message *msg, 
     int rand_offset = -1;
     int terminal_id = codes_mapping_get_lp_relative_id(msg->dest_terminal_lpid, 0, 0);
     const dragonfly_param *p = s->params;
-        
+
     int local_router_id = codes_mapping_get_lp_relative_id(next_stop, 0, 0);
     int src_router = s->router_id;
 
@@ -9118,7 +9132,7 @@ static int get_output_port_legacy(router_state *s, terminal_dally_message *msg, 
         else
         {
             vector< Connection > conns_to_local_router = s->connMan.get_connections_to_gid(local_router_id, CONN_LOCAL);
-            
+
             (*rng_counter)++;
             rand_offset = tw_rand_integer(lp->rng, 0, conns_to_local_router.size()-1);
 
@@ -9153,15 +9167,15 @@ static tw_lpid get_next_stop_legacy(router_state *s, tw_lp *lp, tw_bf *bf, termi
     if(s->group_id == dest_group_id)
     {
         int next_stop = dest_router_id; //trimmed down from old as the old had a lot of superflouous code to poll randomly from a vector of one.
-        
+
         codes_mapping_get_lp_id(lp_group_name, LP_CONFIG_NM_ROUT, s->anno, 0, next_stop / num_routers_per_mgrp,
             next_stop % num_routers_per_mgrp, &router_dest_id);
-    
+
 #if DEBUG == 1
         if(msg->packet_ID == LLU(TRACK_PKT) && msg->src_terminal_id == T_ID)
                 printf("\n Next stop is %d ", next_stop);
 #endif
-        
+
         return router_dest_id;
     }
 
@@ -9170,7 +9184,7 @@ static tw_lpid get_next_stop_legacy(router_state *s, tw_lp *lp, tw_bf *bf, termi
         * adaptive routing). do_chan_selection is turned on in case prog-adaptive
         * routing has just decided to take a non-minimal route. */
     //modified a little to work with connection manager
-    if(msg->last_hop == TERMINAL 
+    if(msg->last_hop == TERMINAL
             || s->router_id == msg->intm_rtr_id
             || (routing == PROG_ADAPTIVE_LEGACY && do_chan_selection))
     {
@@ -9232,14 +9246,14 @@ static int do_global_adaptive_routing_legacy(router_state *s, tw_lp *lp, termina
 {
     int next_chan = -1;
     // decide which routing to take
-    // get the queue occupancy of both the minimal and non-minimal output ports 
+    // get the queue occupancy of both the minimal and non-minimal output ports
 
     bool local_min = false;
     int num_routers = s->params->num_routers;
     int dest_grp_id = dest_router_id / num_routers;
     int intm_grp_id_a = intm_id_a / num_routers;
     int intm_grp_id_b = intm_id_b / num_routers;
-    
+
     assert(intm_grp_id_a >= 0 && intm_grp_id_b >=0);
 
     int my_grp_id = s->router_id / num_routers;
@@ -9290,7 +9304,7 @@ static int do_global_adaptive_routing_legacy(router_state *s, tw_lp *lp, termina
             assert(min_chan_b >= 0);
             noIntraB = false;
             min_rtr_b = connectionList[my_grp_id][dest_grp_id][min_chan_b];
-        
+
             if(min_rtr_b == s->router_id) {
                 noIntraB = true;
                 min_rtr_b = s->connMan.get_connections_to_group(dest_grp_id)[0].dest_gid;
@@ -9305,7 +9319,7 @@ static int do_global_adaptive_routing_legacy(router_state *s, tw_lp *lp, termina
         noIntraB = true;
 
         assert(direct_intra.size() > 0);
-        min_rtr_a = direct_intra[min_chan_a]; 
+        min_rtr_a = direct_intra[min_chan_a];
         dest_rtr_as.push_back(min_rtr_a);
 
         if(num_min_chans > 1)
@@ -9316,7 +9330,7 @@ static int do_global_adaptive_routing_legacy(router_state *s, tw_lp *lp, termina
     int dest_rtr_a_sel = tw_rand_integer(lp->rng, 0, dest_rtr_as.size() - 1);
 
     codes_mapping_get_lp_id(lp_group_name, LP_CONFIG_NM_ROUT, s->anno, 0, dest_rtr_as[dest_rtr_a_sel] / num_routers_per_mgrp,
-            dest_rtr_as[dest_rtr_a_sel] % num_routers_per_mgrp, &min_rtr_a_id); 
+            dest_rtr_as[dest_rtr_a_sel] % num_routers_per_mgrp, &min_rtr_a_id);
 
     min_port_a = get_output_port_legacy(s, msg, lp, bf, min_rtr_a_id, rng_counter);
 
@@ -9327,7 +9341,7 @@ static int do_global_adaptive_routing_legacy(router_state *s, tw_lp *lp, termina
         (*rng_counter)++;
         dest_rtr_b_sel = tw_rand_integer(lp->rng, 0, dest_rtr_bs.size() - 1);
         codes_mapping_get_lp_id(lp_group_name, LP_CONFIG_NM_ROUT, s->anno, 0, dest_rtr_bs[dest_rtr_b_sel] / num_routers_per_mgrp,
-            dest_rtr_bs[dest_rtr_b_sel] % num_routers_per_mgrp, &min_rtr_b_id); 
+            dest_rtr_bs[dest_rtr_b_sel] % num_routers_per_mgrp, &min_rtr_b_id);
         min_port_b = get_output_port_legacy(s, msg, lp, bf, min_rtr_b_id, rng_counter);
     }
 
@@ -9355,7 +9369,7 @@ static int do_global_adaptive_routing_legacy(router_state *s, tw_lp *lp, termina
         assert(rand_a >= 0);
         nonmin_chan_a = rand_a;
         nonmin_rtr_a = connectionList[my_grp_id][intm_grp_id_a][rand_a];
-        if(nonmin_rtr_a == s->router_id) 
+        if(nonmin_rtr_a == s->router_id)
         {
             noIntraA = true;
             nonmin_rtr_a = s->connMan.get_connections_to_group(intm_grp_id_a)[0].dest_gid; //NOTE: This line did not exist in the original but I believe this was what was supposed to happen and it won't work without it, otherwise nonmin_rtr_* is THIS ROUTER
@@ -9363,7 +9377,7 @@ static int do_global_adaptive_routing_legacy(router_state *s, tw_lp *lp, termina
 
     }
     assert(nonmin_chan_a >= 0);
-    
+
     if(num_nonmin_chans_b > 0) {
         noIntraB = false;
         if(nonmin_chan_b != -1) {
@@ -9390,9 +9404,9 @@ static int do_global_adaptive_routing_legacy(router_state *s, tw_lp *lp, termina
 
     (*rng_counter)++;
     dest_rtr_a_sel = tw_rand_integer(lp->rng, 0, dest_rtr_as.size() - 1);
-  
+
     codes_mapping_get_lp_id(lp_group_name, LP_CONFIG_NM_ROUT, s->anno, 0, dest_rtr_as[dest_rtr_a_sel] / num_routers_per_mgrp,
-            dest_rtr_as[dest_rtr_a_sel] % num_routers_per_mgrp, &nonmin_rtr_a_id); 
+            dest_rtr_as[dest_rtr_a_sel] % num_routers_per_mgrp, &nonmin_rtr_a_id);
     nonmin_port_a = get_output_port_legacy(s, msg, lp, bf, nonmin_rtr_a_id, rng_counter);
 
     assert(nonmin_port_a >= 0);
@@ -9405,7 +9419,7 @@ static int do_global_adaptive_routing_legacy(router_state *s, tw_lp *lp, termina
         (*rng_counter)++;
         dest_rtr_b_sel = tw_rand_integer(lp->rng, 0, dest_rtr_bs.size() - 1);
         codes_mapping_get_lp_id(lp_group_name, LP_CONFIG_NM_ROUT, s->anno, 0, dest_rtr_bs[dest_rtr_b_sel] / num_routers_per_mgrp,
-            dest_rtr_bs[dest_rtr_b_sel] % num_routers_per_mgrp, &nonmin_rtr_b_id); 
+            dest_rtr_bs[dest_rtr_b_sel] % num_routers_per_mgrp, &nonmin_rtr_b_id);
         nonmin_port_b = get_output_port_legacy(s, msg, lp, bf, nonmin_rtr_b_id, rng_counter);
         assert(nonmin_port_b >= 0);
     }
@@ -9414,12 +9428,12 @@ static int do_global_adaptive_routing_legacy(router_state *s, tw_lp *lp, termina
     int nonmin_port_a_count = 0, nonmin_port_b_count = 0;
 
     min_port_a_count = get_port_score_legacy(s, min_port_a, 0);
-    
+
     if(num_min_chans > 1)
     {
         min_port_b_count = get_port_score_legacy(s, min_port_b, 0);
     }
-    
+
     nonmin_port_a_count = get_port_score_legacy(s, nonmin_port_a, 1);
 
     if(num_nonmin_chans_b > 0)
@@ -9538,7 +9552,7 @@ static Connection dfdally_prog_adaptive_legacy_routing(router_state *s, tw_bf *b
                 intm_rtr_a = (intm_rtr_a + num_routers) % total_routers;
             if ((intm_rtr_b/num_routers) == my_group_id)
                 intm_rtr_b = (intm_rtr_b + num_routers) % total_routers;
-            
+
             assert(intm_rtr_a / num_routers != my_group_id);
             assert(intm_rtr_b / num_routers != my_group_id);
         }
@@ -9546,27 +9560,27 @@ static Connection dfdally_prog_adaptive_legacy_routing(router_state *s, tw_bf *b
     else
     {
         msg->num_rngs++;
-        intm_rtr_a = (src_grp_id * num_routers) + 
-                        (((s->router_id % num_routers) + 
+        intm_rtr_a = (src_grp_id * num_routers) +
+                        (((s->router_id % num_routers) +
                         tw_rand_integer(lp->rng, 1, num_routers - 1)) % num_routers);
     }
-    
+
     if(routing == NON_MINIMAL)
         msg->path_type = NON_MINIMAL;
-    
+
     /* progressive adaptive routing is only triggered when packet has to traverse a
     * global channel. It doesn't make sense to use it within a group */
-    if(dest_grp_id != src_grp_id && 
-            ((msg->last_hop == TERMINAL 
-                && routing == ADAPTIVE) 
-            || (msg->path_type == MINIMAL 
+    if(dest_grp_id != src_grp_id &&
+            ((msg->last_hop == TERMINAL
+                && routing == ADAPTIVE)
+            || (msg->path_type == MINIMAL
                 && routing == PROG_ADAPTIVE_LEGACY
              // && s->router_id != dest_router_id)))
-                && my_group_id == src_grp_id))) 
+                && my_group_id == src_grp_id)))
     {
         adap_chan = do_global_adaptive_routing_legacy(s, lp, msg, bf, dest_router_id, intm_rtr_a, intm_rtr_b, &(msg->num_rngs));
     }
-    
+
     /* If destination router is in the same group then local adaptive routing is
     * triggered */
     if(msg->origin_router_id == dest_router_id)
@@ -9574,8 +9588,8 @@ static Connection dfdally_prog_adaptive_legacy_routing(router_state *s, tw_bf *b
 
     if(dest_grp_id == src_grp_id &&
             dest_router_id != s->router_id &&
-            (routing == ADAPTIVE || routing == PROG_ADAPTIVE_LEGACY) 
-            && msg->last_hop == TERMINAL) 
+            (routing == ADAPTIVE || routing == PROG_ADAPTIVE_LEGACY)
+            && msg->last_hop == TERMINAL)
     {
             do_local_adaptive_routing_legacy(s, lp, msg, bf, dest_router_id, intm_rtr_a, &(msg->num_rngs));
     }
@@ -9586,9 +9600,9 @@ static Connection dfdally_prog_adaptive_legacy_routing(router_state *s, tw_bf *b
         tw_error(TW_LOC, "\n packet src %d dest %d intm %d src grp %d dest grp %d", s->router_id, dest_router_id, intm_rtr_a, src_grp_id, dest_grp_id);
 
     assert(msg->path_type == MINIMAL || msg->path_type == NON_MINIMAL);
-    
+
     /* If non-minimal, set the random destination */
-    if(msg->last_hop == TERMINAL 
+    if(msg->last_hop == TERMINAL
             && msg->path_type == NON_MINIMAL
             && msg->intm_rtr_id == -1)
     {
@@ -9617,13 +9631,13 @@ static Connection dfdally_prog_adaptive_legacy_routing(router_state *s, tw_bf *b
     || (msg->my_l_hop == max_lvc_intm_g && msg->my_g_hop == min_gvc_intm_g))
         get_direct_con = 1;
     }
-    
+
     /* If the packet route has just changed to non-minimal with prog-adaptive
     * routing, we have to compute the next stop based on that */
     int do_chan_selection = 0;
     if(routing == PROG_ADAPTIVE_LEGACY && prev_path_type != next_path_type && s->group_id == src_grp_id)
         do_chan_selection = 1;
-  
+
     next_stop = get_next_stop_legacy(s, lp, bf, msg, dest_router_id, adap_chan, do_chan_selection, get_direct_con, &(msg->num_rngs));
 
 #if DEBUG == 1
@@ -9631,7 +9645,7 @@ static Connection dfdally_prog_adaptive_legacy_routing(router_state *s, tw_bf *b
         printf("\n Packet %llu arrived at router %u next stop %d final stop %d local hops %d global hops %d", msg->packet_ID, s->router_id, next_stop, dest_router_id, msg->my_l_hop, msg->my_g_hop);
 #endif
 
-    output_port = get_output_port_legacy(s, msg, lp, bf, next_stop, &(msg->num_rngs)); 
+    output_port = get_output_port_legacy(s, msg, lp, bf, next_stop, &(msg->num_rngs));
     assert(output_port >= 0);
 
     Connection return_conn = s->connMan.get_connection_on_port(output_port);
@@ -9654,8 +9668,8 @@ struct model_net_method dragonfly_dally_method =
     dragonfly_dally_get_msg_sz,
     dragonfly_dally_report_stats,
     NULL,
-    NULL,   
-    NULL,//(event_f)dragonfly_dally_sample_fn,    
+    NULL,
+    NULL,//(event_f)dragonfly_dally_sample_fn,
     NULL,//(revent_f)dragonfly_dally_sample_rc_fn,
     (init_f)dragonfly_dally_sample_init,
     NULL,//(final_f)dragonfly_dally_sample_fin
@@ -9700,7 +9714,7 @@ struct model_net_method dragonfly_dally_router_method =
 // #ifdef ENABLE_CORTEX
 
 // static int dragonfly_dally_get_number_of_compute_nodes(void* topo) {
-    
+
 //     const dragonfly_param * params = &all_params[num_params-1];
 //     if(!params)
 //         return -1.0;
@@ -9719,7 +9733,7 @@ struct model_net_method dragonfly_dally_router_method =
 
 // static double dragonfly_dally_get_router_link_bandwidth(void* topo, router_id_t r1, router_id_t r2) {
 //         // TODO: handle this function for multiple cables between the routers.
-//         // Right now it returns the bandwidth of a single cable only. 
+//         // Right now it returns the bandwidth of a single cable only.
 // 	// Given two router ids r1 and r2, this function should return the bandwidth (double)
 // 	// of the link between the two routers, or 0 of such a link does not exist in the topology.
 // 	// The function should return -1 if one of the router id is invalid.
@@ -9765,7 +9779,7 @@ struct model_net_method dragonfly_dally_router_method =
 //             if(bl.dest == r2)
 //                 return params->global_bandwidth;
 //         }
-        
+
 //         return 0.0;
 //     }
 //     return 0.0;
@@ -9779,10 +9793,10 @@ struct model_net_method dragonfly_dally_router_method =
 //     const dragonfly_param * params = &all_params[num_params-1];
 //     if(!params)
 //         return -1.0;
-   
+
 //     if(node < 0 || node >= params->total_terminals)
 //         return -1.0;
-    
+
 //     return params->cn_bandwidth;
 // }
 
@@ -9802,8 +9816,8 @@ struct model_net_method dragonfly_dally_router_method =
 //     set<router_id_t> g_neighbors;
 
 //     map< int, vector<bLink> > &curMap = interGroupLinks[r];
-//     map< int, vector<bLink> >::iterator it = curMap.begin(); 
-//     for(; it != curMap.end(); it++) {   
+//     map< int, vector<bLink> >::iterator it = curMap.begin();
+//     for(; it != curMap.end(); it++) {
 //         for(int l = 0; l < it->second.size(); l++) {
 //             g_neighbors.insert(it->second[l].dest);
 //         }
@@ -9851,13 +9865,13 @@ struct model_net_method dragonfly_dally_router_method =
 //         i++;
 //     }
 //     int g_offset = params->num_router_cols + params->num_router_rows - 2;
-    
+
 //     /* Now fill up global channels */
 //     set<router_id_t> g_neighbors;
 
 //     map< int, vector<bLink> > &curMap = interGroupLinks[r];
-//     map< int, vector<bLink> >::iterator it = curMap.begin(); 
-//     for(; it != curMap.end(); it++) {   
+//     map< int, vector<bLink> >::iterator it = curMap.begin();
+//     for(; it != curMap.end(); it++) {
 //         for(int l = 0; l < it->second.size(); l++) {
 //             g_neighbors.insert(it->second[l].dest);
 //         }
@@ -9880,7 +9894,7 @@ struct model_net_method dragonfly_dally_router_method =
 // 	// for instance, this can be the array [ group_id, router_id ] where group_id is the id of the
 // 	// group in which the router is, and router_id is the id of the router inside this group (as opposed
 // 	// to "r" which is its global id). For a torus network, this would be the dimensions.
-// 	// If the "size" is sufficient to hold the information, the function should return the size 
+// 	// If the "size" is sufficient to hold the information, the function should return the size
 // 	// effectively used (e.g. 2 in the above example). If however the function did not manage to use
 // 	// the provided buffer, it should return -1.
 //     const dragonfly_param * params = &all_params[num_params-1];
@@ -9911,7 +9925,7 @@ struct model_net_method dragonfly_dally_router_method =
 
 //     if(node < 0 || node >= params->total_terminals)
 //         return -1;
-  
+
 //     if(size < 3)
 //         return -1;
 
@@ -9919,7 +9933,7 @@ struct model_net_method dragonfly_dally_router_method =
 //     int rid_global = node / params->num_cn;
 //     int gid = rid_global / params->num_routers;
 //     int lid = node % params->num_cn;
-   
+
 //     location[0] = gid;
 //     location[1] = rid;
 //     location[2] = lid;
@@ -9937,7 +9951,7 @@ struct model_net_method dragonfly_dally_router_method =
 
 //     if(node < 0 || node >= params->total_terminals)
 //         return -1;
-    
+
 //     router_id_t rid = node / params->num_cn;
 //     return rid;
 // }
@@ -9951,7 +9965,7 @@ struct model_net_method dragonfly_dally_router_method =
 
 //     if(r < 0 || r >= params->total_routers)
 //         return -1;
-    
+
 //     return params->num_cn;
 // }
 
@@ -9969,27 +9983,27 @@ struct model_net_method dragonfly_dally_router_method =
 // extern "C" {
 
 // cortex_topology dragonfly_dally_cortex_topology = {
-// //        .internal = 
+// //        .internal =
 // 			NULL,
-// //		  .get_number_of_routers          = 
+// //		  .get_number_of_routers          =
 // 			dragonfly_dally_get_number_of_routers,
-// //		  .get_number_of_compute_nodes	  = 
+// //		  .get_number_of_compute_nodes	  =
 // 			dragonfly_dally_get_number_of_compute_nodes,
-// //        .get_router_link_bandwidth      = 
+// //        .get_router_link_bandwidth      =
 // 			dragonfly_dally_get_router_link_bandwidth,
-// //        .get_compute_node_bandwidth     = 
+// //        .get_compute_node_bandwidth     =
 // 			dragonfly_dally_get_compute_node_bandwidth,
-// //        .get_router_neighbor_count      = 
+// //        .get_router_neighbor_count      =
 // 			dragonfly_dally_get_router_neighbor_count,
-// //        .get_router_neighbor_list       = 
+// //        .get_router_neighbor_list       =
 // 			dragonfly_dally_get_router_neighbor_list,
-// //        .get_router_location            = 
+// //        .get_router_location            =
 // 			dragonfly_dally_get_router_location,
-// //        .get_compute_node_location      = 
+// //        .get_compute_node_location      =
 // 			dragonfly_dally_get_compute_node_location,
-// //        .get_router_from_compute_node   = 
+// //        .get_router_from_compute_node   =
 // 			dragonfly_dally_get_router_from_compute_node,
-// //        .get_router_compute_node_count  = 
+// //        .get_router_compute_node_count  =
 // 			dragonfly_dally_get_router_compute_node_count,
 // //        .get_router_compute_node_list   = dragonfly_dally_get_router_compute_node_list,
 //             dragonfly_dally_get_router_compute_node_list

--- a/src/networks/model-net/dragonfly-plus.C
+++ b/src/networks/model-net/dragonfly-plus.C
@@ -11,6 +11,7 @@
 
 #define DEBUG_LP 892
 #include <map>
+#include <new>
 #include <set>
 #include <vector>
 #include "codes/codes.h"
@@ -296,9 +297,9 @@ struct dragonfly_plus_param
 
     //couting app bandwidth usage percentage on a router
     int counting_bool;
-    tw_stime counting_start; 
-    tw_stime counting_end; 
-    tw_stime counting_interval; 
+    tw_stime counting_start;
+    tw_stime counting_end;
+    tw_stime counting_interval;
     int counting_windows;
 };
 
@@ -474,7 +475,7 @@ static char* get_routing_alg_chararray(int routing_alg_int)
 
 static bool isRoutingAdaptive(int alg)
 {
-    if (alg == PROG_ADAPTIVE || alg == FULLY_PROG_ADAPTIVE || alg == SMART_PROG_ADAPTIVE) 
+    if (alg == PROG_ADAPTIVE || alg == FULLY_PROG_ADAPTIVE || alg == SMART_PROG_ADAPTIVE)
         return true;
     else
         return false;
@@ -501,7 +502,7 @@ static bool isRoutingSmart(int alg)
     if (alg == SMART_MINIMAL || alg == SMART_PROG_ADAPTIVE || alg == SMART_NON_MINIMAL)
         return true;
     else
-        return false;    
+        return false;
 }
 
 
@@ -534,7 +535,7 @@ struct terminal_state
     terminal_plus_message_list ***terminal_msgs_tail; //[rail_id][qos_level]
     int* in_send_loop; //[rail_id]
     struct mn_stats dragonfly_stats_array[CATEGORY_MAX];
-   
+
     int ** qos_status; //[rail_id][qos_level]
     int** qos_data; //[rail_id][qos_level]
 
@@ -614,7 +615,7 @@ struct router_state
 
     tw_stime *next_output_available_time;
     tw_stime *last_buf_full;
-  
+
     /* qos related state variables */
     int num_rtr_rc_windows;
     int is_monitoring_bw;
@@ -657,7 +658,7 @@ struct router_state
 
     //GC occupancy report usage
     //for msg app id counting rec
-    char output_buf4[4096]; 
+    char output_buf4[4096];
     int **msg_counting;
     int **msg_counting_out;
     //counting total number of packets received during all counting windows, used to verify correct reverse computation
@@ -676,22 +677,21 @@ static void ross_dfly_plus_sample_fn(terminal_state * s, tw_bf * bf, tw_lp * lp,
 static void ross_dfly_plus_sample_rc_fn(terminal_state * s, tw_bf * bf, tw_lp * lp, struct dfly_cn_sample *sample);
 
 st_model_types dfly_plus_model_types[] = {
-    {(ev_trace_f) dfly_plus_event_collect,
+    {(ev_trace_f)dfly_plus_event_collect,
      sizeof(int),
-     (model_stat_f) dfly_plus_model_stat_collect,
-     sizeof(tw_lpid) + sizeof(long) * 2 + sizeof(double) + sizeof(tw_stime) *2,
-     (sample_event_f) ross_dfly_plus_sample_fn,
-     (sample_revent_f) ross_dfly_plus_sample_rc_fn,
-     sizeof(struct dfly_cn_sample) } , 
-    {(ev_trace_f) dfly_plus_event_collect,
+     (model_stat_f)dfly_plus_model_stat_collect,
+     sizeof(tw_lpid) + sizeof(long) * 2 + sizeof(double) + sizeof(tw_stime) * 2,
+     (sample_event_f)ross_dfly_plus_sample_fn,
+     (sample_revent_f)ross_dfly_plus_sample_rc_fn,
+     sizeof(struct dfly_cn_sample)},
+    {(ev_trace_f)dfly_plus_event_collect,
      sizeof(int),
-     (model_stat_f) dfly_plus_router_model_stat_collect,
-     0, //updated in router_plus_init() since it's based on the radix
-     (sample_event_f) ross_dfly_plus_rsample_fn,
-     (sample_revent_f) ross_dfly_plus_rsample_rc_fn,
-     0 } , //updated in router_plus_init() since it's based on the radix    
-    {NULL, 0, NULL, 0, NULL, NULL, 0}
-};
+     (model_stat_f)dfly_plus_router_model_stat_collect,
+     0, // updated in router_plus_init() since it's based on the radix
+     (sample_event_f)ross_dfly_plus_rsample_fn,
+     (sample_revent_f)ross_dfly_plus_rsample_rc_fn,
+     0}, // updated in router_plus_init() since it's based on the radix
+    {NULL, 0, NULL, 0, NULL, NULL, 0}};
 /* End of ROSS model instrumentation */
 
 // event tracing callback - used router and terminal LPs
@@ -713,7 +713,7 @@ void dfly_plus_model_stat_collect(terminal_state *s, tw_lp *lp, char *buffer)
     tw_lpid id = 0;
     long tmp = 0;
     tw_stime tmp2 = 0;
-    
+
     id = s->terminal_id;
     memcpy(&buffer[index], &id, sizeof(id));
     index += sizeof(id);
@@ -754,7 +754,7 @@ void dfly_plus_router_model_stat_collect(router_state *s, tw_lp *lp, char *buffe
 {
     (void)lp;
 
-    const dragonfly_plus_param * p = s->params; 
+    const dragonfly_plus_param *p = s->params;
     int i, index = 0;
 
     tw_lpid id = 0;
@@ -770,12 +770,12 @@ void dfly_plus_router_model_stat_collect(router_state *s, tw_lp *lp, char *buffe
         tmp = s->busy_time_ross_sample[i];
         memcpy(&buffer[index], &tmp, sizeof(tmp));
         index += sizeof(tmp);
-        s->busy_time_ross_sample[i] = 0; 
+        s->busy_time_ross_sample[i] = 0;
 
         tmp2 = s->link_traffic_ross_sample[i];
         memcpy(&buffer[index], &tmp2, sizeof(tmp2));
         index += sizeof(tmp2);
-        s->link_traffic_ross_sample[i] = 0; 
+        s->link_traffic_ross_sample[i] = 0;
     }
     return;
 }
@@ -808,7 +808,7 @@ static void ross_dfly_plus_rsample_fn(router_state * s, tw_bf * bf, tw_lp * lp, 
     (void)lp;
     (void)bf;
 
-    const dragonfly_plus_param * p = s->params; 
+    const dragonfly_plus_param *p = s->params;
     int i = 0;
 
     sample->router_id = s->router_id;
@@ -820,8 +820,8 @@ static void ross_dfly_plus_rsample_fn(router_state * s, tw_bf * bf, tw_lp * lp, 
 
     for(; i < p->radix; i++)
     {
-        sample->busy_time[i] = s->ross_rsample.busy_time[i]; 
-        sample->link_traffic_sample[i] = s->ross_rsample.link_traffic_sample[i]; 
+        sample->busy_time[i] = s->ross_rsample.busy_time[i];
+        sample->link_traffic_sample[i] = s->ross_rsample.link_traffic_sample[i];
     }
 
     /* clear up the current router stats */
@@ -840,7 +840,7 @@ static void ross_dfly_plus_rsample_rc_fn(router_state * s, tw_bf * bf, tw_lp * l
 {
     (void)lp;
     (void)bf;
-    
+
     const dragonfly_plus_param * p = s->params;
     int i =0;
 
@@ -859,7 +859,7 @@ static void ross_dfly_plus_sample_fn(terminal_state * s, tw_bf * bf, tw_lp * lp,
 {
     (void)lp;
     (void)bf;
-    
+
     sample->terminal_id = s->terminal_id;
     sample->fin_chunks_sample = s->ross_sample.fin_chunks_sample;
     sample->data_size_sample = s->ross_sample.data_size_sample;
@@ -1040,7 +1040,7 @@ void dragonfly_plus_sample_init(terminal_state *s, tw_lp *lp)
     s->sample_stat = (dfly_cn_sample *) calloc(MAX_STATS, sizeof(struct dfly_cn_sample));
     for(int i = 0; i < s->max_arr_size; i++)
     {
-        s->sample_stat[i].busy_time_sample = (tw_stime*)calloc(s->params->num_rails, sizeof(tw_stime)); 
+        s->sample_stat[i].busy_time_sample = (tw_stime *)calloc(s->params->num_rails, sizeof(tw_stime));
     }
 }
 void dragonfly_plus_sample_rc_fn(terminal_state *s, tw_bf *bf, terminal_plus_message *msg, tw_lp *lp)
@@ -1282,7 +1282,7 @@ static int dfp_score_connection(router_state *s, tw_bf *bf, terminal_plus_messag
 
             //score normalized to port size if FPAR is used
             if (routing == FULLY_PROG_ADAPTIVE) {
-                score = (int)((double)score/port_size *100);                
+                score = (int)((double)score / port_size * 100);
             }
             break;
         }
@@ -1349,7 +1349,7 @@ static Connection get_absolute_best_connection_from_conns(router_state *s, tw_bf
     int best_score_index = 0;
     vector<int> best_indexes; //in case multiple ports are equally best, choose a random one
     if (scoring_preference == LOWER) {
-        
+
         int best_score = INT_MAX;
         for(int i = 0; i < num_to_compare; i++)
         {
@@ -1366,7 +1366,7 @@ static Connection get_absolute_best_connection_from_conns(router_state *s, tw_bf
         }
     }
     else {
-        
+
         int best_score = 0;
         for(int i = 0; i < num_to_compare; i++)
         {
@@ -1428,7 +1428,7 @@ static Connection get_absolute_best_connection_from_conn_set(router_state *s, tw
     }
 
     assert(best_conns.size() > 0);
-    
+
     msg->num_rngs++;
     return best_conns[tw_rand_integer(lp->rng, 0, best_conns.size()-1)];
 }
@@ -1509,7 +1509,7 @@ static Connection get_best_connection_from_conns(router_state *s, tw_bf *bf, ter
     int best_score_index = 0;
     vector<int> best_indexes; //in case multiple ports are equally best, choose a random one
     if (scoring_preference == LOWER) {
-        
+
         int best_score = INT_MAX;
         for(int i = 0; i < num_to_compare; i++)
         {
@@ -1526,7 +1526,7 @@ static Connection get_best_connection_from_conns(router_state *s, tw_bf *bf, ter
         }
     }
     else {
-        
+
         int best_score = 0;
         for(int i = 0; i < num_to_compare; i++)
         {
@@ -1581,7 +1581,7 @@ int dragonfly_plus_get_assigned_router_id(const dragonfly_plus_param *p, int ter
     int num_rails = p->num_rails;
     int total_routers = p->total_routers;
     int total_terminals = p->total_terminals;
-    
+
     int group_id = terminal_id / num_cn_per_group;
     int planar_group_id = group_id % num_groups;
     int local_router_id = (terminal_id / num_cn) % num_router_leaf;
@@ -1745,7 +1745,7 @@ void dragonfly_plus_print_params(const dragonfly_plus_param *p, FILE * st)
     fprintf(st,"\tdest_spine_consider_gnonmin = %s\n", (p->dest_spine_consider_global_nonmin ? "true" : "false"));
     fprintf(st,"\tmax hops notification =       %d\n",p->max_hops_notify);
     if (p->counting_bool > 0)
-    {   
+    {
         fprintf(st,"\tcounting msg app id =         Yes\n");
         fprintf(st,"\tcounting_start(ns) =          %.2f\n",p->counting_start);
         fprintf(st,"\tcounting_end(ns) =            %.2f\n",p->counting_end);
@@ -1799,21 +1799,21 @@ static void dragonfly_read_config(const char *anno, dragonfly_plus_param *params
         if(rc1 || rc2 || rc3)
             tw_error(TW_LOC, "\n Missing couting values, (counting_start/end/interval) check for config files\n");
 
-        p->counting_windows = (int) round((p->counting_end - p->counting_start)/p->counting_interval); 
+        p->counting_windows = (int)round((p->counting_end - p->counting_start) / p->counting_interval);
 
         //convert us to ns
         p->counting_start = p->counting_start * 1000;
         p->counting_end = p->counting_end * 1000;
         p->counting_interval = p->counting_interval * 1000;
     }
-    
+
     rc = configuration_get_value_int(&config, "PARAMS", "num_qos_levels", anno, &p->num_qos_levels);
     if(rc) {
         p->num_qos_levels = 1;
         if(!myRank)
             fprintf(stderr, "Number of QOS levels not specified, setting to %d\n", p->num_qos_levels);
     }
-    
+
     char qos_levels_str[MAX_NAME_LENGTH];
     rc = configuration_get_value(&config, "PARAMS", "qos_bandwidth", anno, qos_levels_str, MAX_NAME_LENGTH);
     p->qos_bandwidths = (int*)calloc(p->num_qos_levels, sizeof(int));
@@ -2021,7 +2021,7 @@ static void dragonfly_read_config(const char *anno, dragonfly_plus_param *params
 
     /* MM: This should be 2 for dragonfly plus*/
     p->num_vcs = 2;
-    
+
     if(p->num_qos_levels > 1)
         p->num_vcs = p->num_qos_levels * p->num_vcs;
 
@@ -2192,7 +2192,7 @@ static void dragonfly_read_config(const char *anno, dragonfly_plus_param *params
 
     InterGroupLink newInterLink;
     while (fread(&newInterLink, sizeof(InterGroupLink), 1, systemFile) != 0) {
-        
+
         for(int i = 0; i < p->num_planes; i++)
         {
             int read_src_id_global = newInterLink.src;
@@ -2214,14 +2214,15 @@ static void dragonfly_read_config(const char *anno, dragonfly_plus_param *params
     }
 
     //read link failure file
-    char failureFileName[MAX_NAME_LENGTH];   
+    char failureFileName[MAX_NAME_LENGTH];
     failureFileName[0] = '\0';
 
     if (strlen(g_nm_link_failure_filepath) == 0) //was this defined already via a command line argument?
     {
-        configuration_get_value(&config, "PARAMS", "link-failure-file", 
-            anno, failureFileName, MAX_NAME_LENGTH);
-        if (strlen(failureFileName) > 0) {
+        configuration_get_value(&config, "PARAMS", "link-failure-file",
+                                anno, failureFileName, MAX_NAME_LENGTH);
+        if (strlen(failureFileName) > 0)
+        {
             netMan.enable_link_failures();
         }
     }
@@ -2231,25 +2232,26 @@ static void dragonfly_read_config(const char *anno, dragonfly_plus_param *params
         netMan.enable_link_failures();
     }
 
-    if(netMan.is_link_failures_enabled())
+    if (netMan.is_link_failures_enabled())
     {
-        if(!myRank)
+        if (!myRank)
             printf("\nDragonfly Plus: Link Failures Feature Enabled\n");
 
         FILE *failureFile = fopen(failureFileName, "rb");
         if (!failureFile)
-            tw_error(TW_LOC, "link failure file not found: %s\n",failureFileName);
+            tw_error(TW_LOC, "link failure file not found: %s\n", failureFileName);
 
         if (!myRank)
-        fprintf(stderr, "Reading link failure file: %s\n", failureFileName);
+            fprintf(stderr, "Reading link failure file: %s\n", failureFileName);
 
         Link_Info link;
-        while (fread(&link, sizeof(Link_Info), 1, failureFile) != 0) {
+        while (fread(&link, sizeof(Link_Info), 1, failureFile) != 0)
+        {
             netMan.add_link_failure_info(link);
         }
     }
 
-    netMan.solidify_network(); //finalize link failures and burn the network links into the Connection managers 
+    netMan.solidify_network(); // finalize link failures and burn the network links into the Connection managers
 
     if (DUMP_CONNECTIONS)
     {
@@ -2272,7 +2274,7 @@ static void dragonfly_read_config(const char *anno, dragonfly_plus_param *params
         else
             router_type_map[i] = SPINE;
     }
-    
+
     if (!myRank) {
         printf("\nTotal nodes: %d,  Total routers: %d, Num groups: %d, Routers per group: %d, Virtual radix: %d\n",
                p->num_cn * p->num_router_leaf * p->num_groups, p->total_routers, p->num_groups, p->num_routers, p->radix);
@@ -2308,7 +2310,7 @@ static void dragonfly_read_config(const char *anno, dragonfly_plus_param *params
     }
 
     double general_credit_delay;
-    int credit_delay_unset = configuration_get_value_double(&config, "PARAMS", "credit_delay", anno, &general_credit_delay); 
+    int credit_delay_unset = configuration_get_value_double(&config, "PARAMS", "credit_delay", anno, &general_credit_delay);
     int local_credit_delay_unset = configuration_get_value_double(&config, "PARAMS", "local_credit_delay", anno, &p->local_credit_delay);
     int global_credit_delay_unset = configuration_get_value_double(&config, "PARAMS", "global_credit_delay", anno, &p->global_credit_delay);
     int cn_credit_delay_unset = configuration_get_value_double(&config, "PARAMS", "cn_credit_delay", anno, &p->cn_credit_delay);
@@ -2326,7 +2328,7 @@ static void dragonfly_read_config(const char *anno, dragonfly_plus_param *params
     //If the user specifies a general "credit_delay" AND any of the more specific credit delays, throw an error to make sure they correct their configuration
     if (!credit_delay_unset && !(local_credit_delay_unset || global_credit_delay_unset || cn_credit_delay_unset))
         tw_error(TW_LOC, "\nCannot set both a general credit delay and specific (local/global/cn) credit delays. Check configuration file.");
-    
+
     //If the user specifies ANY credit delays general or otherwise AND has the auto credit delay flag enabled, throw an error to make sure they correct the conflicting configuration
     if ((!credit_delay_unset || !local_credit_delay_unset || !global_credit_delay_unset || !cn_credit_delay_unset) && auto_credit_delay_flag)
         tw_error(TW_LOC, "\nCannot set both a credit delay (general or specific) and also enable auto credit delay calculation. Check Configuration file.");
@@ -2352,7 +2354,7 @@ static void dragonfly_read_config(const char *anno, dragonfly_plus_param *params
         if (global_credit_delay_unset) {
             p->global_credit_delay = bytes_to_ns(p->credit_size, p->global_bandwidth);
             if(!myRank && !auto_credit_delay_flag) //if the auto credit delay flag is true then we've already printed what we're going to do
-                fprintf(stderr, "global_credit_delay not specified, using calculation based on global bandwidth: %.2f\n", p->global_credit_delay);   
+                fprintf(stderr, "global_credit_delay not specified, using calculation based on global bandwidth: %.2f\n", p->global_credit_delay);
         }
         if (cn_credit_delay_unset) {
             p->cn_credit_delay = bytes_to_ns(p->credit_size, p->cn_bandwidth);
@@ -2365,7 +2367,7 @@ static void dragonfly_read_config(const char *anno, dragonfly_plus_param *params
         p->local_credit_delay = general_credit_delay;
         p->global_credit_delay = general_credit_delay;
         p->cn_credit_delay = general_credit_delay;
-        
+
         if(!myRank)
             fprintf(stderr, "general credit_delay specified - all credit delays set to %.2f\n",general_credit_delay);
     }
@@ -2426,7 +2428,7 @@ void dragonfly_plus_report_stats()
 
     /* print statistics */
     if (!g_tw_mynode) {
-        if (PRINT_CONFIG) 
+        if (PRINT_CONFIG)
             dragonfly_plus_print_params(stored_params, NULL);
 
 
@@ -2497,53 +2499,52 @@ void issue_bw_monitor_event_rc(terminal_state * s, tw_bf * bf, terminal_plus_mes
 {
     for(int i = 0 ; i < msg->num_cll; i++)
         codes_local_latency_reverse(lp);
-    
+
     int num_qos_levels = s->params->num_qos_levels;
-    
+
     if(msg->rc_is_qos_set == 1)
     {
         for(int i = 0; i < num_qos_levels; i++)
         {
             s->qos_data[msg->rail_id][i] = msg->rc_qos_data[i]; //rail id of data put into the rc data is the same as the one it's being extracted to.
-            s->qos_status[msg->rail_id][i] = msg->rc_qos_status[i];  
+            s->qos_status[msg->rail_id][i] = msg->rc_qos_status[i];
         }
 
         free(msg->rc_qos_data);
         free(msg->rc_qos_status);
         msg->rc_is_qos_set = 0;
     }
-    
 }
 /* resets the bandwidth numbers recorded so far */
-void issue_bw_monitor_event(terminal_state * s, tw_bf * bf, terminal_plus_message * msg, tw_lp * lp)
+void issue_bw_monitor_event(terminal_state *s, tw_bf *bf, terminal_plus_message *msg, tw_lp *lp)
 {
-   
+
     msg->num_cll = 0;
     msg->num_rngs = 0;
     int num_qos_levels = s->params->num_qos_levels;
     int num_rails = s->params->num_rails;
-    
-    //RC data storage start.
-    //Allocate memory here for these pointers that are stored in the events. FREE THESE IN RC OR IN COMMIT_F
-    msg->rc_qos_data = (unsigned long long *) calloc(num_rails*num_qos_levels, sizeof(unsigned long long));
-    msg->rc_qos_status = (int *) calloc(num_rails*num_qos_levels, sizeof(int));
 
-    //store qos data and status into the arrays. Pointers to the arrays are stored in events.
-    for(int i = 0; i < num_rails; i++)
+    // RC data storage start.
+    // Allocate memory here for these pointers that are stored in the events. FREE THESE IN RC OR IN COMMIT_F
+    msg->rc_qos_data = (unsigned long long *)calloc(num_rails * num_qos_levels, sizeof(unsigned long long));
+    msg->rc_qos_status = (int *)calloc(num_rails * num_qos_levels, sizeof(int));
+
+    // store qos data and status into the arrays. Pointers to the arrays are stored in events.
+    for (int i = 0; i < num_rails; i++)
     {
-        for(int j = 0; j < num_qos_levels; j++)
+        for (int j = 0; j < num_qos_levels; j++)
         {
             *(indexer2d(msg->rc_qos_data, i, j, num_rails, num_qos_levels)) = s->qos_data[i][j];
             *(indexer2d(msg->rc_qos_status, i, j, num_rails, num_qos_levels)) = s->qos_status[i][j];
         }
     }
     msg->rc_is_qos_set = 1;
-    //RC data storage end.
+    // RC data storage end.
 
     /* Reset the qos status and bandwidth consumption. */
-    for(int i = 0; i < num_rails; i++)
+    for (int i = 0; i < num_rails; i++)
     {
-        for(int j = 0; j < num_qos_levels; j++)
+        for (int j = 0; j < num_qos_levels; j++)
         {
             s->qos_status[j][i] = Q_ACTIVE;
             s->qos_data[j][i] = 0;
@@ -2552,16 +2553,16 @@ void issue_bw_monitor_event(terminal_state * s, tw_bf * bf, terminal_plus_messag
         s->ross_sample.busy_time_sample[i] = 0;
     }
 
-    if(tw_now(lp) > max_qos_monitor)
+    if (tw_now(lp) > max_qos_monitor)
         return;
-    
+
     msg->num_cll++;
-    terminal_plus_message * m; 
+    terminal_plus_message *m;
     tw_stime bw_ts = bw_reset_window + codes_local_latency(lp);
-    tw_event * e = model_net_method_event_new(lp->gid, bw_ts, lp, DRAGONFLY_PLUS,
-            (void**)&m, NULL); 
+    tw_event *e = model_net_method_event_new(lp->gid, bw_ts, lp, DRAGONFLY_PLUS,
+                                             (void **)&m, NULL);
     m->type = T_BANDWIDTH;
-    m->magic = terminal_magic_num; 
+    m->magic = terminal_magic_num;
     tw_event_send(e);
 }
 
@@ -2596,33 +2597,31 @@ void issue_rtr_bw_monitor_event(router_state *s, tw_bf *bf, terminal_plus_messag
 
     int radix = s->params->radix;
     int num_qos_levels = s->params->num_qos_levels;
-    
 
-    //RC data storage start.
-    //Allocate memory here for these pointers that are stored in the events. FREE THESE IN RC OR IN COMMIT_F
-    msg->rc_qos_data = (unsigned long long *) calloc(radix * num_qos_levels, sizeof(unsigned long long));
-    msg->rc_qos_status = (int *) calloc(radix * num_qos_levels, sizeof(int));
+    // RC data storage start.
+    // Allocate memory here for these pointers that are stored in the events. FREE THESE IN RC OR IN COMMIT_F
+    msg->rc_qos_data = (unsigned long long *)calloc(radix * num_qos_levels, sizeof(unsigned long long));
+    msg->rc_qos_status = (int *)calloc(radix * num_qos_levels, sizeof(int));
 
-    //store qos data and status into the arrays. Pointers to the arrays are stored in events.
-    for(int i = 0; i < radix; i++)
+    // store qos data and status into the arrays. Pointers to the arrays are stored in events.
+    for (int i = 0; i < radix; i++)
     {
-        for(int j = 0; j < num_qos_levels; j++)
+        for (int j = 0; j < num_qos_levels; j++)
         {
             *(indexer2d(msg->rc_qos_data, i, j, radix, num_qos_levels)) = s->qos_data[i][j];
             *(indexer2d(msg->rc_qos_status, i, j, radix, num_qos_levels)) = s->qos_status[i][j];
         }
     }
     msg->rc_is_qos_set = 1;
-    //RC data storage end.
+    // RC data storage end.
 
-
-    for(int i = 0; i < radix; i++)
+    for (int i = 0; i < radix; i++)
     {
-        for(int j = 0; j < num_qos_levels; j++)
+        for (int j = 0; j < num_qos_levels; j++)
         {
             int bw_consumed = get_rtr_bandwidth_consumption(s, j, i);
-        
-            #if DEBUG_QOS == 1 
+
+#if DEBUG_QOS == 1
             if(dragonfly_rtr_bw_log != NULL && ROUTER_BW_LOG)
             {
                 if(s->qos_data[j][k] > 0)
@@ -2630,7 +2629,7 @@ void issue_rtr_bw_monitor_event(router_state *s, tw_bf *bf, terminal_plus_messag
                     fprintf(dragonfly_rtr_bw_log, "\n %d %f %d %d %d %d %d %f", s->router_id, tw_now(lp), i, j, bw_consumed, s->qos_status[i][j], s->qos_data[i][j], s->busy_time_sample[i]);
                 }
             }
-            #endif   
+#endif
         }
     }
 
@@ -2648,7 +2647,7 @@ void issue_rtr_bw_monitor_event(router_state *s, tw_bf *bf, terminal_plus_messag
 
     if(tw_now(lp) > max_qos_monitor)
         return;
-    
+
     msg->num_cll++;
     tw_stime bw_ts = bw_reset_window + codes_local_latency(lp);
     terminal_plus_message *m;
@@ -2662,7 +2661,7 @@ void issue_rtr_bw_monitor_event(router_state *s, tw_bf *bf, terminal_plus_messag
 static int get_next_vcg(terminal_state * s, tw_bf * bf, terminal_plus_message * msg, tw_lp * lp)
 {
     int num_qos_levels = s->params->num_qos_levels;
-  
+
     if(num_qos_levels == 1)
     {
         if(s->terminal_msgs[msg->rail_id][0] == NULL || s->vc_occupancy[msg->rail_id][0] + s->params->chunk_size > s->params->cn_vc_size)
@@ -2679,13 +2678,13 @@ static int get_next_vcg(terminal_state * s, tw_bf * bf, terminal_plus_message * 
         if(s->qos_status[msg->rail_id][k] != Q_OVERBW)
         {
             bw_consumption[k] = get_term_bandwidth_consumption(s, msg->rail_id, k);
-            if(bw_consumption[k] > s->params->qos_bandwidths[k]) 
+            if (bw_consumption[k] > s->params->qos_bandwidths[k])
             {
                 if(k == 0)
                     msg->qos_reset1 = 1;
                 else if(k == 1)
                     msg->qos_reset2 = 1;
-                
+
                 s->qos_status[msg->rail_id][k] = Q_OVERBW;
             }
         }
@@ -2709,10 +2708,10 @@ static int get_next_vcg(terminal_state * s, tw_bf * bf, terminal_plus_message * 
         if(s->terminal_msgs[msg->rail_id][i] != NULL && s->vc_occupancy[msg->rail_id][i] + s->params->chunk_size <= s->params->cn_vc_size)
         {
             bf->c2 = 1;
-            
+
             if(msg->last_saved_qos < 0)
                 msg->last_saved_qos = s->last_qos_lvl[msg->rail_id];
-            
+
             s->last_qos_lvl[msg->rail_id] = next_rr_vcg;
             return i;
         }
@@ -2729,7 +2728,7 @@ static int get_next_router_vcg(router_state * s, tw_bf * bf, terminal_plus_messa
   int output_port = msg->vc_index;
   int vcg = 0;
   int base_limit = 0;
-    
+
   int chunk_size = s->params->chunk_size;
   int bw_consumption[num_qos_levels];
   /* First make sure the bandwidth consumptions are up to date. */
@@ -2740,16 +2739,16 @@ static int get_next_router_vcg(router_state * s, tw_bf * bf, terminal_plus_messa
         if(s->qos_status[output_port][k] != Q_OVERBW)
         {
             bw_consumption[k] = get_rtr_bandwidth_consumption(s, k, output_port);
-            if(bw_consumption[k] > s->params->qos_bandwidths[k]) 
-        {
-//            printf("\n Router %d QoS %d exceeded allowed bandwidth %d ", s->router_id, k, bw_consumption[k]);
-            if(k == 0)
-                msg->qos_reset1 = 1;   
-            else if(k == 1)
-                msg->qos_reset2 = 1;
+            if (bw_consumption[k] > s->params->qos_bandwidths[k])
+            {
+                //            printf("\n Router %d QoS %d exceeded allowed bandwidth %d ", s->router_id, k, bw_consumption[k]);
+                if (k == 0)
+                    msg->qos_reset1 = 1;
+                else if (k == 1)
+                    msg->qos_reset2 = 1;
 
-            s->qos_status[output_port][k] = Q_OVERBW;
-        }
+                s->qos_status[output_port][k] = Q_OVERBW;
+            }
       }
   }
   int vc_size = s->params->global_vc_size;
@@ -2771,24 +2770,24 @@ static int get_next_router_vcg(router_state * s, tw_bf * bf, terminal_plus_messa
         }
    }
   }
-       
+
    /* All vcgs are exceeding their bandwidth limits*/
    msg->last_saved_qos = s->last_qos_lvl[output_port];
    int next_rr_vcg = (s->last_qos_lvl[output_port] + 1) % num_qos_levels;
 
    for(int i = 0; i < num_qos_levels; i++)
    {
-        base_limit = next_rr_vcg * vcs_per_qos; 
-        for(int k = base_limit; k < base_limit + vcs_per_qos; k++)
-        {
-            if(s->pending_msgs[output_port][k] != NULL)
-            {
-                if(msg->last_saved_qos < 0)
-                    msg->last_saved_qos = s->last_qos_lvl[output_port]; 
+       base_limit = next_rr_vcg * vcs_per_qos;
+       for (int k = base_limit; k < base_limit + vcs_per_qos; k++)
+       {
+           if (s->pending_msgs[output_port][k] != NULL)
+           {
+               if (msg->last_saved_qos < 0)
+                   msg->last_saved_qos = s->last_qos_lvl[output_port];
 
-                s->last_qos_lvl[output_port] = next_rr_vcg;
-                return k;
-            }
+               s->last_qos_lvl[output_port] = next_rr_vcg;
+               return k;
+           }
         }
         next_rr_vcg = (next_rr_vcg + 1) % num_qos_levels;
         assert(next_rr_vcg < 2);
@@ -2796,10 +2795,10 @@ static int get_next_router_vcg(router_state * s, tw_bf * bf, terminal_plus_messa
    return -1;
 }
 
-void terminal_plus_commit(terminal_state * s,
-		tw_bf * bf, 
-		terminal_plus_message * msg, 
-        tw_lp * lp)
+void terminal_plus_commit(terminal_state *s,
+                          tw_bf *bf,
+                          terminal_plus_message *msg,
+                          tw_lp *lp)
 {
     if(msg->type == T_BANDWIDTH)
     {
@@ -2811,10 +2810,10 @@ void terminal_plus_commit(terminal_state * s,
     }
 }
 
-void router_plus_commit(router_state * s,
-		tw_bf * bf, 
-		terminal_plus_message * msg, 
-        tw_lp * lp)
+void router_plus_commit(router_state *s,
+                        tw_bf *bf,
+                        terminal_plus_message *msg,
+                        tw_lp *lp)
 {
     if(msg->type == R_BANDWIDTH)
     {
@@ -2856,67 +2855,71 @@ void terminal_plus_init(terminal_state *s, tw_lp *lp)
 
     int num_qos_levels = s->params->num_qos_levels;
     int num_lps = codes_mapping_get_lp_count(lp_group_name, 1, LP_CONFIG_NM_TERM, s->anno, 0);
-    
 
     s->terminal_id = codes_mapping_get_lp_relative_id(lp->gid, 0, 0);
-    s->router_id = (unsigned int*)calloc(p->num_rails, sizeof(unsigned int));
-    s->router_lp = (tw_lpid*)calloc(p->num_rails, sizeof(tw_lpid));
+    s->router_id = (unsigned int *)calloc(p->num_rails, sizeof(unsigned int));
+    s->router_lp = (tw_lpid *)calloc(p->num_rails, sizeof(tw_lpid));
 
+    // ROSS allocates LP state as a zeroed POD blob and never runs C++ ctors.
+    // Assigning into a never-constructed map-of-maps is UB; libc++ (macOS)
+    // segfaults walking the begin-node sentinel, libstdc++ (Linux) tolerates
+    // the zero-init and can produce nondeterministic test failures.
+    // TODO: drop once make_lptype<T>() trampoline lands.
+    new (&s->connMan) DragonflyConnectionManager();
     s->connMan = netMan.get_connection_manager_for_terminal(s->terminal_id);
 
-
-    for(i = 0; i < p->num_rails; i++)
+    for (i = 0; i < p->num_rails; i++)
     {
-        s->router_id[i] = dragonfly_plus_get_assigned_router_id(s->params,s->terminal_id,i);
-        num_routers_per_mgrp = codes_mapping_get_lp_count (lp_group_name, 1, "modelnet_dragonfly_plus_router",
-            NULL, 0);
+        s->router_id[i] = dragonfly_plus_get_assigned_router_id(s->params, s->terminal_id, i);
+        num_routers_per_mgrp = codes_mapping_get_lp_count(lp_group_name, 1, "modelnet_dragonfly_plus_router",
+                                                          NULL, 0);
         codes_mapping_get_lp_id(lp_group_name, LP_CONFIG_NM_ROUT, NULL, 1, s->router_id[i] / num_routers_per_mgrp, s->router_id[i] % num_routers_per_mgrp, &s->router_lp[i]);
     }
 
     // printf("%d gid is TERMINAL %d with assigned router %d\n",lp->gid,s->terminal_id,s->router_id);
-    s->terminal_available_time = (tw_stime*)calloc(p->num_rails, sizeof(tw_stime));
+    s->terminal_available_time = (tw_stime *)calloc(p->num_rails, sizeof(tw_stime));
     s->packet_counter = 0;
     s->min_latency = INT_MAX;
     s->max_latency = 0;
 
-    s->link_traffic=(uint64_t*)calloc(p->num_rails, sizeof(uint64_t));
+    s->link_traffic = (uint64_t *)calloc(p->num_rails, sizeof(uint64_t));
     s->finished_msgs = 0;
     s->finished_chunks = 0;
     s->finished_packets = 0;
     s->total_time = 0.0;
     s->total_msg_size = 0;
 
-    s->stalled_chunks = (unsigned long*)calloc(p->num_rails, sizeof(uint64_t));
-    s->busy_time = (tw_stime*)calloc(p->num_rails, sizeof(tw_stime));
+    s->stalled_chunks = (unsigned long *)calloc(p->num_rails, sizeof(uint64_t));
+    s->busy_time = (tw_stime *)calloc(p->num_rails, sizeof(tw_stime));
 
     s->fwd_events = 0;
     s->rev_events = 0;
 
     rc_stack_create(&s->st);
-    
+
     s->num_vcs = 1;
-    if(num_qos_levels > 1)
+    if (num_qos_levels > 1)
         s->num_vcs *= num_qos_levels;
-   
-    s->vc_occupancy = (int**)calloc(p->num_rails, sizeof(int*));
-    s->last_buf_full = (tw_stime*)calloc(p->num_rails, sizeof(tw_stime));
 
-    s->terminal_length = (int**)calloc(p->num_rails, sizeof(int*)); //1 vc times number of qos levels
+    s->vc_occupancy = (int **)calloc(p->num_rails, sizeof(int *));
+    s->last_buf_full = (tw_stime *)calloc(p->num_rails, sizeof(tw_stime));
 
-    for(i = 0; i < p->num_rails; i++)
+    s->terminal_length = (int **)calloc(p->num_rails, sizeof(int *)); // 1 vc times number of qos levels
+
+    for (i = 0; i < p->num_rails; i++)
     {
-        s->vc_occupancy[i]= (int*)calloc(num_qos_levels, sizeof(int));
-        s->terminal_length[i]= (int*)calloc(num_qos_levels, sizeof(int));
+        s->vc_occupancy[i] = (int *)calloc(num_qos_levels, sizeof(int));
+        s->terminal_length[i] = (int *)calloc(num_qos_levels, sizeof(int));
     }
 
-    s->in_send_loop = (int*)calloc(p->num_rails, sizeof(int));
-    s->issueIdle = (int*)calloc(p->num_rails, sizeof(int));
+    s->in_send_loop = (int *)calloc(p->num_rails, sizeof(int));
+    s->issueIdle = (int *)calloc(p->num_rails, sizeof(int));
 
     s->rank_tbl = NULL;
-    s->terminal_msgs = 
-        (terminal_plus_message_list***)calloc(p->num_rails, sizeof(terminal_plus_message_list**));
-    s->terminal_msgs_tail = 
-        (terminal_plus_message_list***)calloc(p->num_rails, sizeof(terminal_plus_message_list**));
+    s->terminal_msgs =
+        (terminal_plus_message_list ***)calloc(p->num_rails, sizeof(terminal_plus_message_list **));
+    s->terminal_msgs_tail =
+        (terminal_plus_message_list ***)calloc(p->num_rails, sizeof(terminal_plus_message_list **));
 
     /* Whether the virtual channel group is active or over-bw*/
     s->qos_status = (int**)calloc(p->num_rails, sizeof(int*));
@@ -3016,121 +3019,125 @@ void router_plus_init(router_state *r, tw_lp *lp)
         assert(router_type_map[r->router_id] == LEAF);
         // printf("%lu: %i is a LEAF\n",lp->gid, r->router_id);
     }
-#if DEBUG_QOS == 1 
-        char rtr_bw_log[128];
-        sprintf(rtr_bw_log, "router-bw-tracker-%d", g_tw_mynode);
-       
-        if(dragonfly_rtr_bw_log == NULL && ROUTER_BW_LOG)
-        {
-            dragonfly_rtr_bw_log = fopen(rtr_bw_log, "w+");
-       
-           fprintf(dragonfly_rtr_bw_log, "\n router-id time-stamp port-id qos-level bw-consumed qos-status qos-data busy-time");
-        }
-#endif 
-    r->connMan = netMan.get_connection_manager_for_router(r->router_id);
+#if DEBUG_QOS == 1
+    char rtr_bw_log[128];
+    sprintf(rtr_bw_log, "router-bw-tracker-%d", g_tw_mynode);
 
-    r->gc_usage = (int *) calloc(p->num_global_connections, sizeof(int));
+    if (dragonfly_rtr_bw_log == NULL && ROUTER_BW_LOG)
+    {
+        dragonfly_rtr_bw_log = fopen(rtr_bw_log, "w+");
 
-    r->global_channel = (int *) calloc(p->num_global_connections, sizeof(int));
-    r->next_output_available_time = (tw_stime *) calloc(p->radix, sizeof(tw_stime));
-    r->link_traffic = (int64_t *) calloc(p->radix, sizeof(int64_t));
-    r->link_traffic_sample = (int64_t *) calloc(p->radix, sizeof(int64_t));
-
-    r->stalled_chunks = (unsigned long*)calloc(p->radix, sizeof(unsigned long));
-
-    r->vc_occupancy = (int **) calloc(p->radix, sizeof(int *));
-    r->qos_data = (unsigned long long**)calloc(p->radix, sizeof(unsigned long long*));
-    r->last_qos_lvl = (int*)calloc(p->radix, sizeof(int));
-    r->qos_status = (int**)calloc(p->radix, sizeof(int*));
-    r->in_send_loop = (int *) calloc(p->radix, sizeof(int));
-    r->pending_msgs =
-        (terminal_plus_message_list ***) calloc(p->radix, sizeof(terminal_plus_message_list **));
-    r->pending_msgs_tail =
-        (terminal_plus_message_list ***) calloc(p->radix, sizeof(terminal_plus_message_list **));
-    r->queued_msgs =
-        (terminal_plus_message_list ***) calloc(p->radix, sizeof(terminal_plus_message_list **));
-    r->queued_msgs_tail =
-        (terminal_plus_message_list ***) calloc(p->radix, sizeof(terminal_plus_message_list **));
-    r->queued_count = (int *) calloc(p->radix, sizeof(int));
-    r->last_buf_full = (tw_stime*) calloc(p->radix, sizeof(tw_stime *));
-    r->busy_time = (tw_stime *) calloc(p->radix, sizeof(tw_stime));
-    r->busy_time_sample = (tw_stime *) calloc(p->radix, sizeof(tw_stime));
-
-    /* set up for ROSS stats sampling */
-    r->link_traffic_ross_sample = (int64_t*)calloc(p->radix, sizeof(int64_t));
-    r->busy_time_ross_sample = (tw_stime*)calloc(p->radix, sizeof(tw_stime));
-    if (g_st_model_stats)
-        lp->model_types->mstat_sz = sizeof(tw_lpid) + (sizeof(int64_t) + sizeof(tw_stime)) * p->radix;
-    if (g_st_use_analysis_lps && g_st_model_stats)
-        lp->model_types->sample_struct_sz = sizeof(struct dfly_router_sample) + (sizeof(tw_stime) + sizeof(int64_t)) * p->radix;
-    r->ross_rsample.busy_time = (tw_stime*)calloc(p->radix, sizeof(tw_stime));
-    r->ross_rsample.link_traffic_sample = (int64_t*)calloc(p->radix, sizeof(int64_t));
-
-    //for counting app message percentage 
-    if(p->counting_bool > 0)
-    {   
-        r->total_packets_received = 0;
-        r->total_packets_sent = 0;
-        r->msg_counting = (int **) calloc(p->counting_windows, sizeof(int *));
-        r->msg_counting_out = (int **) calloc(p->counting_windows, sizeof(int *));
-
-        for (int i = 0; i < p->counting_windows; ++i)
-        {
-            r->msg_counting[i] = (int*) calloc(2, sizeof(int));
-            r->msg_counting_out[i] = (int*) calloc(2, sizeof(int));
-
-            r->msg_counting[i][0] = 0;
-            r->msg_counting[i][1] = 0;
-
-            r->msg_counting_out[i][0] = 0;
-            r->msg_counting_out[i][1] = 0;
-        }
+        fprintf(dragonfly_rtr_bw_log, "\n router-id time-stamp port-id qos-level bw-consumed qos-status qos-data busy-time");
     }
+#endif
+        // TODO: drop once make_lptype<T>() trampoline lands.
+        new (&r->connMan) DragonflyConnectionManager();
+        r->connMan = netMan.get_connection_manager_for_router(r->router_id);
 
-    rc_stack_create(&r->st);
+        r->gc_usage = (int *)calloc(p->num_global_connections, sizeof(int));
 
-    for (int i = 0; i < p->radix; i++) {
-        // Set credit & router occupancy
-        r->last_buf_full[i] = 0.0;
-        r->busy_time[i] = 0.0;
-        r->busy_time_sample[i] = 0.0;
-        r->next_output_available_time[i] = 0;
-        r->last_qos_lvl[i] = 0;
-        r->link_traffic[i] = 0;
-        r->link_traffic_sample[i] = 0;
-        r->queued_count[i] = 0;
-        r->in_send_loop[i] = 0;
-        r->vc_occupancy[i] = (int *) calloc(p->num_vcs, sizeof(int));
-        r->pending_msgs[i] =
-            (terminal_plus_message_list **) calloc(p->num_vcs, sizeof(terminal_plus_message_list *));
-        r->pending_msgs_tail[i] =
-            (terminal_plus_message_list **) calloc(p->num_vcs, sizeof(terminal_plus_message_list *));
-        r->queued_msgs[i] =
-            (terminal_plus_message_list **) calloc(p->num_vcs, sizeof(terminal_plus_message_list *));
-        r->queued_msgs_tail[i] =
-            (terminal_plus_message_list **) calloc(p->num_vcs, sizeof(terminal_plus_message_list *));
-    
-        r->qos_status[i] = (int*)calloc(num_qos_levels, sizeof(int));
-        r->qos_data[i] = (unsigned long long*)calloc(num_qos_levels, sizeof(unsigned long long));
-    
-        for(int j = 0; j < num_qos_levels; j++)
+        r->global_channel = (int *)calloc(p->num_global_connections, sizeof(int));
+        r->next_output_available_time = (tw_stime *)calloc(p->radix, sizeof(tw_stime));
+        r->link_traffic = (int64_t *)calloc(p->radix, sizeof(int64_t));
+        r->link_traffic_sample = (int64_t *)calloc(p->radix, sizeof(int64_t));
+
+        r->stalled_chunks = (unsigned long *)calloc(p->radix, sizeof(unsigned long));
+
+        r->vc_occupancy = (int **)calloc(p->radix, sizeof(int *));
+        r->qos_data = (unsigned long long **)calloc(p->radix, sizeof(unsigned long long *));
+        r->last_qos_lvl = (int *)calloc(p->radix, sizeof(int));
+        r->qos_status = (int **)calloc(p->radix, sizeof(int *));
+        r->in_send_loop = (int *)calloc(p->radix, sizeof(int));
+        r->pending_msgs =
+            (terminal_plus_message_list ***)calloc(p->radix, sizeof(terminal_plus_message_list **));
+        r->pending_msgs_tail =
+            (terminal_plus_message_list ***)calloc(p->radix, sizeof(terminal_plus_message_list **));
+        r->queued_msgs =
+            (terminal_plus_message_list ***)calloc(p->radix, sizeof(terminal_plus_message_list **));
+        r->queued_msgs_tail =
+            (terminal_plus_message_list ***)calloc(p->radix, sizeof(terminal_plus_message_list **));
+        r->queued_count = (int *)calloc(p->radix, sizeof(int));
+        r->last_buf_full = (tw_stime *)calloc(p->radix, sizeof(tw_stime *));
+        r->busy_time = (tw_stime *)calloc(p->radix, sizeof(tw_stime));
+        r->busy_time_sample = (tw_stime *)calloc(p->radix, sizeof(tw_stime));
+
+        /* set up for ROSS stats sampling */
+        r->link_traffic_ross_sample = (int64_t *)calloc(p->radix, sizeof(int64_t));
+        r->busy_time_ross_sample = (tw_stime *)calloc(p->radix, sizeof(tw_stime));
+        if (g_st_model_stats)
+            lp->model_types->mstat_sz = sizeof(tw_lpid) + (sizeof(int64_t) + sizeof(tw_stime)) * p->radix;
+        if (g_st_use_analysis_lps && g_st_model_stats)
+            lp->model_types->sample_struct_sz = sizeof(struct dfly_router_sample) + (sizeof(tw_stime) + sizeof(int64_t)) * p->radix;
+        r->ross_rsample.busy_time = (tw_stime *)calloc(p->radix, sizeof(tw_stime));
+        r->ross_rsample.link_traffic_sample = (int64_t *)calloc(p->radix, sizeof(int64_t));
+
+        // for counting app message percentage
+        if (p->counting_bool > 0)
         {
-            r->qos_status[i][j] = Q_ACTIVE;
-            r->qos_data[i][j] = 0;
-        }
-        for (int j = 0; j < p->num_vcs; j++) {
-            r->vc_occupancy[i][j] = 0;
-            r->pending_msgs[i][j] = NULL;
-            r->pending_msgs_tail[i][j] = NULL;
-            r->queued_msgs[i][j] = NULL;
-            r->queued_msgs_tail[i][j] = NULL;
-        }
-    }
+            r->total_packets_received = 0;
+            r->total_packets_sent = 0;
+            r->msg_counting = (int **)calloc(p->counting_windows, sizeof(int *));
+            r->msg_counting_out = (int **)calloc(p->counting_windows, sizeof(int *));
 
-    if (!r->connMan.check_is_solidified())
-        tw_error(TW_LOC, "Connection Manager not solidified - should be performed after loading topology");
+            for (int i = 0; i < p->counting_windows; ++i)
+            {
+                r->msg_counting[i] = (int *)calloc(2, sizeof(int));
+                r->msg_counting_out[i] = (int *)calloc(2, sizeof(int));
 
-    return;
+                r->msg_counting[i][0] = 0;
+                r->msg_counting[i][1] = 0;
+
+                r->msg_counting_out[i][0] = 0;
+                r->msg_counting_out[i][1] = 0;
+            }
+        }
+
+        rc_stack_create(&r->st);
+
+        for (int i = 0; i < p->radix; i++)
+        {
+            // Set credit & router occupancy
+            r->last_buf_full[i] = 0.0;
+            r->busy_time[i] = 0.0;
+            r->busy_time_sample[i] = 0.0;
+            r->next_output_available_time[i] = 0;
+            r->last_qos_lvl[i] = 0;
+            r->link_traffic[i] = 0;
+            r->link_traffic_sample[i] = 0;
+            r->queued_count[i] = 0;
+            r->in_send_loop[i] = 0;
+            r->vc_occupancy[i] = (int *)calloc(p->num_vcs, sizeof(int));
+            r->pending_msgs[i] =
+                (terminal_plus_message_list **)calloc(p->num_vcs, sizeof(terminal_plus_message_list *));
+            r->pending_msgs_tail[i] =
+                (terminal_plus_message_list **)calloc(p->num_vcs, sizeof(terminal_plus_message_list *));
+            r->queued_msgs[i] =
+                (terminal_plus_message_list **)calloc(p->num_vcs, sizeof(terminal_plus_message_list *));
+            r->queued_msgs_tail[i] =
+                (terminal_plus_message_list **)calloc(p->num_vcs, sizeof(terminal_plus_message_list *));
+
+            r->qos_status[i] = (int *)calloc(num_qos_levels, sizeof(int));
+            r->qos_data[i] = (unsigned long long *)calloc(num_qos_levels, sizeof(unsigned long long));
+
+            for (int j = 0; j < num_qos_levels; j++)
+            {
+                r->qos_status[i][j] = Q_ACTIVE;
+                r->qos_data[i][j] = 0;
+            }
+            for (int j = 0; j < p->num_vcs; j++)
+            {
+                r->vc_occupancy[i][j] = 0;
+                r->pending_msgs[i][j] = NULL;
+                r->pending_msgs_tail[i][j] = NULL;
+                r->queued_msgs[i][j] = NULL;
+                r->queued_msgs_tail[i][j] = NULL;
+            }
+        }
+
+        if (!r->connMan.check_is_solidified())
+            tw_error(TW_LOC, "Connection Manager not solidified - should be performed after loading topology");
+
+        return;
 }
 
 /* dragonfly packet event reverse handler */
@@ -3221,7 +3228,7 @@ static void packet_generate_rc(terminal_state *s, tw_bf *bf, terminal_plus_messa
         num_local_packets_sg--;
     if(bf->c4)
         num_remote_packets--;
-   
+
     for(int i = 0; i < msg->num_rngs; i++)
         tw_rand_reverse_unif(lp->rng);
 
@@ -3236,15 +3243,14 @@ static void packet_generate_rc(terminal_state *s, tw_bf *bf, terminal_plus_messa
     if (msg->packet_size < s->params->chunk_size)
         num_chunks++;
 
-   
     int vcg = 0;
-    if(num_qos_levels > 1)
+    if (num_qos_levels > 1)
     {
-       vcg = get_vcg_from_category(msg); 
-       assert(vcg == Q_HIGH || vcg == Q_MEDIUM);
+        vcg = get_vcg_from_category(msg);
+        assert(vcg == Q_HIGH || vcg == Q_MEDIUM);
     }
     assert(vcg < num_qos_levels);
-    
+
     int i;
     for (i = 0; i < num_chunks; i++) {
             delete_terminal_plus_message_list(return_tail(s->terminal_msgs[msg->rail_id], s->terminal_msgs_tail[msg->rail_id], vcg));
@@ -3257,8 +3263,8 @@ static void packet_generate_rc(terminal_state *s, tw_bf *bf, terminal_plus_messa
     int* scs = (int*)rc_stack_pop(s->st);
     int* iis = (int*)rc_stack_pop(s->st);
     tw_stime* bts = (tw_stime*)rc_stack_pop(s->st);
-    
-    for(int j = 0; j < s->params->num_injection_queues; j++) 
+
+    for (int j = 0; j < s->params->num_injection_queues; j++)
     {
         s->last_buf_full[j] = bts[j];
         s->issueIdle[j] = iis[j];
@@ -3274,7 +3280,7 @@ static void packet_generate_rc(terminal_state *s, tw_bf *bf, terminal_plus_messa
     //     if(bf->c8)
     //         s->last_buf_full[msg->rail_id] = msg->saved_busy_time;
     // }
-    
+
     struct mn_stats *stat;
     stat = model_net_find_stats(msg->category, s->dragonfly_stats_array);
     stat->send_count--;
@@ -3287,11 +3293,11 @@ static void packet_generate(terminal_state *s, tw_bf *bf, terminal_plus_message 
 {
     msg->num_rngs = 0;
     msg->num_cll = 0;
-    
+
     packet_gen++;
     s->packet_gen++;
     s->total_gen_size += msg->packet_size;
-    
+
     tw_stime ts, nic_ts;
 
     assert(lp->gid != msg->dest_terminal_id);
@@ -3348,7 +3354,8 @@ static void packet_generate(terminal_state *s, tw_bf *bf, terminal_plus_message 
                 // }
             }
         }
-        if (valid_rails.size() < 1) { 
+        if (valid_rails.size() < 1)
+        {
             tw_error(TW_LOC,"Invalid Connections in Network due to link failures!\n");
             // valid_rails = injection_connections; //TODO will cause problems - deal with
         }
@@ -3378,7 +3385,7 @@ static void packet_generate(terminal_state *s, tw_bf *bf, terminal_plus_message 
             }
 
         }
-        
+
         if (s->params->rail_select == RAIL_PATH) {
             int path_lens[valid_rails.size()];
             int min_len = 99999;
@@ -3459,8 +3466,8 @@ static void packet_generate(terminal_state *s, tw_bf *bf, terminal_plus_message 
 
     int dest_router_id = dragonfly_plus_get_assigned_router_id(p, msg->dfp_dest_terminal_id, msg->rail_id);
     int dest_grp_id = dest_router_id / s->params->num_routers;
-    int src_grp_id = s->router_id[msg->rail_id] / s->params->num_routers; 
-    
+    int src_grp_id = s->router_id[msg->rail_id] / s->params->num_routers;
+
     if(src_grp_id == dest_grp_id)
     {
         if(dest_router_id == s->router_id[msg->rail_id])
@@ -3512,7 +3519,7 @@ static void packet_generate(terminal_state *s, tw_bf *bf, terminal_plus_message 
             terminal_dally_message * m;
             tw_event * e = model_net_method_event_new(lp->gid, bw_ts, lp, DRAGONFLY_PLUS,
                 (void**)&m, NULL);
-            m->type = T_BANDWIDTH; 
+            m->type = T_BANDWIDTH;
             m->magic = terminal_magic_num;
             s->is_monitoring_bw = 1;
             tw_event_send(e);
@@ -3623,7 +3630,7 @@ static void packet_send_rc(terminal_state * s, tw_bf * bf, terminal_plus_message
         s->qos_status[msg->rail_id][0] = Q_ACTIVE;
     if(msg->qos_reset2)
         s->qos_status[msg->rail_id][1] = Q_ACTIVE;
-    
+
     if(msg->last_saved_qos)
         s->last_qos_lvl[msg->rail_id] = msg->last_saved_qos;
 
@@ -3633,39 +3640,42 @@ static void packet_send_rc(terminal_state * s, tw_bf * bf, terminal_plus_message
             s->last_buf_full[msg->rail_id] = msg->saved_busy_time;
         return;
     }
-     
-    for(int i = 0; i < msg->num_cll; i++) 
+
+    for (int i = 0; i < msg->num_cll; i++)
     {
         codes_local_latency_reverse(lp);
     }
-  
+
     for(int i = 0; i < msg->num_rngs; i++)
     {
         tw_rand_reverse_unif(lp->rng);
     }
     int vcg = msg->saved_vc;
     s->terminal_available_time[msg->rail_id] = msg->saved_available_time;
-    
+
     s->terminal_length[msg->rail_id][vcg] += s->params->chunk_size;    /*TODO: MM change this to the vcg */
     s->vc_occupancy[msg->rail_id][vcg] -= s->params->chunk_size;
     s->link_traffic[msg->rail_id]-=s->params->chunk_size;
 
     terminal_plus_message_list* cur_entry = (terminal_plus_message_list *)rc_stack_pop(s->st);
-    
+
     int data_size = s->params->chunk_size;
     if(cur_entry->msg.packet_size < s->params->chunk_size)
         data_size = cur_entry->msg.packet_size % s->params->chunk_size;
 
     s->qos_data[msg->rail_id][vcg] -= data_size;
 
-    prepend_to_terminal_plus_message_list(s->terminal_msgs[msg->rail_id], 
-            s->terminal_msgs_tail[msg->rail_id], vcg, cur_entry);
-    if(bf->c4) {
+    prepend_to_terminal_plus_message_list(s->terminal_msgs[msg->rail_id],
+                                          s->terminal_msgs_tail[msg->rail_id], vcg, cur_entry);
+    if (bf->c4)
+    {
         s->in_send_loop[msg->rail_id] = 1;
     }
-    if (bf->c5) {
+    if (bf->c5)
+    {
         s->issueIdle[msg->rail_id] = 1;
-        if (bf->c6) {
+        if (bf->c6)
+        {
             s->busy_time[msg->rail_id] = msg->saved_total_time;
             s->last_buf_full[msg->rail_id] = msg->saved_busy_time;
             s->busy_time_sample[msg->rail_id] = msg->saved_sample_time;
@@ -3682,25 +3692,26 @@ static void packet_send(terminal_state *s, tw_bf *bf, terminal_plus_message *msg
     tw_event *e;
     terminal_plus_message *m;
     tw_lpid router_id;
-  
+
     int vcg = 0;
     int num_qos_levels = s->params->num_qos_levels;
- 
+
     msg->last_saved_qos = -1;
     msg->qos_reset1 = -1;
     msg->qos_reset2 = -1;
     msg->num_rngs = 0;
     msg->num_cll = 0;
-  
-    vcg = get_next_vcg(s, bf, msg, lp);
-  
-    /* For a terminal to router Connection, there would be as many VCGs as number
-    * of VCs*/
 
-    if(vcg == -1) {
+    vcg = get_next_vcg(s, bf, msg, lp);
+
+    /* For a terminal to router Connection, there would be as many VCGs as number
+     * of VCs*/
+
+    if (vcg == -1)
+    {
         bf->c1 = 1;
         s->in_send_loop[msg->rail_id] = 0;
-        if(!s->last_buf_full[msg->rail_id])
+        if (!s->last_buf_full[msg->rail_id])
         {
             bf->c3 = 1;
             msg->saved_busy_time = s->last_buf_full[msg->rail_id];
@@ -3708,16 +3719,17 @@ static void packet_send(terminal_state *s, tw_bf *bf, terminal_plus_message *msg
         }
         return;
     }
-    
+
     msg->saved_vc = vcg;
-    terminal_plus_message_list* cur_entry = s->terminal_msgs[msg->rail_id][vcg];
+    terminal_plus_message_list *cur_entry = s->terminal_msgs[msg->rail_id][vcg];
     int data_size = s->params->chunk_size;
     uint64_t num_chunks = cur_entry->msg.packet_size / s->params->chunk_size;
     if (cur_entry->msg.packet_size < s->params->chunk_size)
         num_chunks++;
 
     tw_stime delay = s->params->cn_delay;
-    if ((cur_entry->msg.packet_size < s->params->chunk_size) && (cur_entry->msg.chunk_id == num_chunks - 1)) {
+    if ((cur_entry->msg.packet_size < s->params->chunk_size) && (cur_entry->msg.chunk_id == num_chunks - 1))
+    {
         data_size = cur_entry->msg.packet_size % s->params->chunk_size;
         delay = bytes_to_ns(cur_entry->msg.packet_size % s->params->chunk_size, s->params->cn_bandwidth);
     }
@@ -3737,9 +3749,10 @@ static void packet_send(terminal_state *s, tw_bf *bf, terminal_plus_message *msg
     //  printf("\n Local router id %d global router id %d ", s->router_id, router_id);
     // we are sending an event to the router, so no method_event here
     void *remote_event;
-    e = model_net_method_event_new(router_id, ts, lp, DRAGONFLY_PLUS_ROUTER, (void **) &m, &remote_event);
+    e = model_net_method_event_new(router_id, ts, lp, DRAGONFLY_PLUS_ROUTER, (void **)&m, &remote_event);
     memcpy(m, &cur_entry->msg, sizeof(terminal_plus_message));
-    if (m->remote_event_size_bytes) {
+    if (m->remote_event_size_bytes)
+    {
         memcpy(remote_event, cur_entry->event_data, m->remote_event_size_bytes);
     }
 
@@ -3756,57 +3769,60 @@ static void packet_send(terminal_state *s, tw_bf *bf, terminal_plus_message *msg
     m->dfp_upward_channel_flag = 0;
     tw_event_send(e);
 
-
-    if (cur_entry->msg.chunk_id == num_chunks - 1 && (cur_entry->msg.local_event_size_bytes > 0)) {
+    if (cur_entry->msg.chunk_id == num_chunks - 1 && (cur_entry->msg.local_event_size_bytes > 0))
+    {
         msg->num_cll++;
         tw_stime local_ts = codes_local_latency(lp);
         tw_event *e_new = tw_event_new(cur_entry->msg.sender_lp, local_ts, lp);
         void *m_new = tw_event_data(e_new);
-        void *local_event = (char *) cur_entry->event_data + cur_entry->msg.remote_event_size_bytes;
+        void *local_event = (char *)cur_entry->event_data + cur_entry->msg.remote_event_size_bytes;
         memcpy(m_new, local_event, cur_entry->msg.local_event_size_bytes);
         tw_event_send(e_new);
     }
-  
+
     // s->packet_counter++;
     s->vc_occupancy[msg->rail_id][vcg] += s->params->chunk_size;
-    cur_entry = return_head(s->terminal_msgs[msg->rail_id], s->terminal_msgs_tail[msg->rail_id], vcg); 
+    cur_entry = return_head(s->terminal_msgs[msg->rail_id], s->terminal_msgs_tail[msg->rail_id], vcg);
     rc_stack_push(lp, cur_entry, delete_terminal_plus_message_list, s->st);
     s->terminal_length[msg->rail_id][vcg] -= s->params->chunk_size;
     s->link_traffic[msg->rail_id] += s->params->chunk_size;
-    
-    int next_vcg = 0; 
-  
-    if(num_qos_levels > 1)
-      next_vcg = get_next_vcg(s, bf, msg, lp);
+
+    int next_vcg = 0;
+
+    if (num_qos_levels > 1)
+        next_vcg = get_next_vcg(s, bf, msg, lp);
 
     cur_entry = NULL;
-    if(next_vcg >= 0)
+    if (next_vcg >= 0)
         cur_entry = s->terminal_msgs[msg->rail_id][next_vcg];
 
     /* if there is another packet inline then schedule another send event */
-    if (cur_entry != NULL && s->vc_occupancy[msg->rail_id][next_vcg] + s->params->chunk_size <= s->params->cn_vc_size) {
+    if (cur_entry != NULL && s->vc_occupancy[msg->rail_id][next_vcg] + s->params->chunk_size <= s->params->cn_vc_size)
+    {
         terminal_plus_message *m_new;
         msg->num_rngs++;
         ts += tw_rand_unif(lp->rng);
-        e = model_net_method_event_new(lp->gid, ts, lp, DRAGONFLY_PLUS, (void **) &m_new, NULL);
+        e = model_net_method_event_new(lp->gid, ts, lp, DRAGONFLY_PLUS, (void **)&m_new, NULL);
         m_new->type = T_SEND;
         m_new->rail_id = msg->rail_id;
         m_new->magic = terminal_magic_num;
         tw_event_send(e);
     }
-    else {
+    else
+    {
         /* If not then the LP will wait for another credit or packet generation */
         bf->c4 = 1;
         s->in_send_loop[msg->rail_id] = 0;
     }
-    if(s->issueIdle[msg->rail_id]) {
+    if (s->issueIdle[msg->rail_id])
+    {
         bf->c5 = 1;
         s->issueIdle[msg->rail_id] = 0;
         msg->num_rngs++;
         ts += tw_rand_unif(lp->rng);
         model_net_method_idle_event2(ts, 0, msg->rail_id, lp);
 
-        if(s->last_buf_full[msg->rail_id] > 0.0)
+        if (s->last_buf_full[msg->rail_id] > 0.0)
         {
             bf->c6 = 1;
             msg->saved_total_time = s->busy_time[msg->rail_id];
@@ -3831,7 +3847,8 @@ static void send_remote_event(terminal_state *s, terminal_plus_message *msg, tw_
     // tw_stime ts = g_tw_lookahead + bytes_to_ns(msg->remote_event_size_bytes, (1/s->params->cn_bandwidth));
     msg->num_rngs++;
     tw_stime ts = g_tw_lookahead + mpi_soft_overhead + tw_rand_unif(lp->rng);
-    if (msg->is_pull) {
+    if (msg->is_pull)
+    {
         bf->c4 = 1;
         struct codes_mctx mc_dst = codes_mctx_set_global_direct(msg->sender_mn_lp);
         struct codes_mctx mc_src = codes_mctx_set_global_direct(lp->gid);
@@ -3842,7 +3859,8 @@ static void send_remote_event(terminal_state *s, terminal_plus_message *msg, tw_
         msg->event_rc = model_net_event_mctx(net_id, &mc_src, &mc_dst, msg->category, msg->sender_lp,
                                              msg->pull_size, ts, remote_event_size, tmp_ptr, 0, NULL, lp);
     }
-    else {
+    else
+    {
         tw_event *e = tw_event_new(msg->final_dest_gid, ts, lp);
         void *m_remote = tw_event_data(e);
         memcpy(m_remote, event_data, remote_event_size);
@@ -3853,13 +3871,14 @@ static void send_remote_event(terminal_state *s, terminal_plus_message *msg, tw_
 
 static void packet_arrive_rc(terminal_state *s, tw_bf *bf, terminal_plus_message *msg, tw_lp *lp)
 {
-    for(int i = 0; i < msg->num_rngs; i++)
-      tw_rand_reverse_unif(lp->rng);
+    for (int i = 0; i < msg->num_rngs; i++)
+        tw_rand_reverse_unif(lp->rng);
 
-    for(int i = 0; i < msg->num_cll; i++)
-      codes_local_latency_reverse(lp);
-      
-    if (bf->c31) {
+    for (int i = 0; i < msg->num_cll; i++)
+        codes_local_latency_reverse(lp);
+
+    if (bf->c31)
+    {
         s->packet_fin--;
         packet_fin--;
     }
@@ -3900,17 +3919,20 @@ static void packet_arrive_rc(terminal_state *s, tw_bf *bf, terminal_plus_message
     stat = model_net_find_stats(msg->category, s->dragonfly_stats_array);
     stat->recv_time = msg->saved_rcv_time;
 
-    if (bf->c1) {
+    if (bf->c1)
+    {
         stat->recv_count--;
         stat->recv_bytes -= msg->packet_size;
         N_finished_packets--;
         s->finished_packets--;
     }
 
-    if (bf->c22) {
+    if (bf->c22)
+    {
         s->max_latency = msg->saved_available_time;
     }
-    if (bf->c7) {
+    if (bf->c7)
+    {
         // assert(!hash_link);
         N_finished_msgs--;
         s->finished_msgs--;
@@ -3920,7 +3942,7 @@ static void packet_arrive_rc(terminal_state *s, tw_bf *bf, terminal_plus_message
         s->ross_sample.data_size_sample -= msg->total_size;
         s->data_size_ross_sample -= msg->total_size;
 
-        struct dfly_qhash_entry *d_entry_pop = (dfly_qhash_entry *) rc_stack_pop(s->st);
+        struct dfly_qhash_entry *d_entry_pop = (dfly_qhash_entry *)rc_stack_pop(s->st);
         qhash_add(s->rank_tbl, &key, &(d_entry_pop->hash_link));
         s->rank_tbl_pop++;
 
@@ -3937,7 +3959,8 @@ static void packet_arrive_rc(terminal_state *s, tw_bf *bf, terminal_plus_message
     assert(tmp);
     tmp->num_chunks--;
 
-    if (bf->c5) {
+    if (bf->c5)
+    {
         qhash_del(hash_link);
         free_tmp(tmp);
         s->rank_tbl_pop--;
@@ -3951,11 +3974,11 @@ static void packet_arrive(terminal_state *s, tw_bf *bf, terminal_plus_message *m
     // NIC aggregation - should this be a separate function?
     // Trigger an event on receiving server
 
-    if(isRoutingMinimal(routing) && msg->my_N_hop > 4)
+    if (isRoutingMinimal(routing) && msg->my_N_hop > 4)
     {
         printf("TERMINAL RECEIVED A NONMINIMAL LENGTH PACKET\n");
     }
-    if(isRoutingMinimal(routing) && msg->my_g_hop > 1)
+    if (isRoutingMinimal(routing) && msg->my_g_hop > 1)
     {
         printf("TERMINAL RECEIVED A DOUBLE GLOBAL HOP PACKET\n");
     }
@@ -3963,9 +3986,9 @@ static void packet_arrive(terminal_state *s, tw_bf *bf, terminal_plus_message *m
 
     if (msg->my_N_hop > s->params->max_hops_notify)
     {
-        printf("Terminal received a packet with %d hops! (Notify on > than %d)\n",msg->my_N_hop, s->params->max_hops_notify);
+        printf("Terminal received a packet with %d hops! (Notify on > than %d)\n", msg->my_N_hop, s->params->max_hops_notify);
     }
-    
+
     msg->num_rngs = 0;
     msg->num_cll = 0;
 
@@ -4013,7 +4036,7 @@ static void packet_arrive(terminal_state *s, tw_bf *bf, terminal_plus_message *m
     tw_event *buf_e;
     terminal_plus_message *buf_msg;
     buf_e =
-        model_net_method_event_new(msg->intm_lp_id, ts, lp, DRAGONFLY_PLUS_ROUTER, (void **) &buf_msg, NULL);
+        model_net_method_event_new(msg->intm_lp_id, ts, lp, DRAGONFLY_PLUS_ROUTER, (void **)&buf_msg, NULL);
     buf_msg->magic = router_magic_num;
     buf_msg->rail_id = msg->rail_id;
     buf_msg->vc_index = msg->vc_index;
@@ -4040,7 +4063,7 @@ static void packet_arrive(terminal_state *s, tw_bf *bf, terminal_plus_message *m
 
     // Verify that the router that send the packet to this terminal is the router assigned to this terminal
     int dest_router_id = dragonfly_plus_get_assigned_router_id(s->params, s->terminal_id, msg->rail_id);
-    int received_from_rel_id = codes_mapping_get_lp_relative_id(msg->intm_lp_id,0,0);
+    int received_from_rel_id = codes_mapping_get_lp_relative_id(msg->intm_lp_id, 0, 0);
     assert(dest_router_id == received_from_rel_id);
 
     uint64_t num_chunks = msg->packet_size / s->params->chunk_size;
@@ -4052,7 +4075,8 @@ static void packet_arrive(terminal_state *s, tw_bf *bf, terminal_plus_message *m
     else
         nonmin_count++;
 
-    if (msg->chunk_id == num_chunks - 1) {
+    if (msg->chunk_id == num_chunks - 1)
+    {
         bf->c31 = 1;
         s->packet_fin++;
         packet_fin++;
@@ -4081,8 +4105,9 @@ static void packet_arrive(terminal_state *s, tw_bf *bf, terminal_plus_message *m
     stat->recv_time += (tw_now(lp) - msg->travel_start_time);
 
 #if DEBUG == 1
-    if (msg->packet_ID == TRACK && msg->chunk_id == num_chunks - 1 && msg->message_id == TRACK_MSG) {
-        printf("(%lf) [Terminal %d] packet %lld has arrived  \n", tw_now(lp), (int) lp->gid, msg->packet_ID);
+    if (msg->packet_ID == TRACK && msg->chunk_id == num_chunks - 1 && msg->message_id == TRACK_MSG)
+    {
+        printf("(%lf) [Terminal %d] packet %lld has arrived  \n", tw_now(lp), (int)lp->gid, msg->packet_ID);
 
         printf("travel start time is %f\n", msg->travel_start_time);
 
@@ -4095,9 +4120,10 @@ static void packet_arrive(terminal_state *s, tw_bf *bf, terminal_plus_message *m
     void *m_data_src = model_net_method_get_edata(DRAGONFLY_PLUS, msg);
 
     /* If an entry does not exist then create one */
-    if (!tmp) {
+    if (!tmp)
+    {
         bf->c5 = 1;
-        struct dfly_qhash_entry *d_entry = (dfly_qhash_entry *) calloc(1, sizeof(struct dfly_qhash_entry));
+        struct dfly_qhash_entry *d_entry = (dfly_qhash_entry *)calloc(1, sizeof(struct dfly_qhash_entry));
         d_entry->num_chunks = 0;
         d_entry->key = key;
         d_entry->remote_event_data = NULL;
@@ -4115,7 +4141,8 @@ static void packet_arrive(terminal_state *s, tw_bf *bf, terminal_plus_message *m
     assert(tmp);
     tmp->num_chunks++;
 
-    if (msg->chunk_id == num_chunks - 1) {
+    if (msg->chunk_id == num_chunks - 1)
+    {
         bf->c1 = 1;
         stat->recv_count++;
         stat->recv_bytes += msg->packet_size;
@@ -4124,18 +4151,21 @@ static void packet_arrive(terminal_state *s, tw_bf *bf, terminal_plus_message *m
         s->finished_packets++;
     }
     /* if its the last chunk of the packet then handle the remote event data */
-    if (msg->remote_event_size_bytes > 0 && !tmp->remote_event_data) {
+    if (msg->remote_event_size_bytes > 0 && !tmp->remote_event_data)
+    {
         /* Retreive the remote event entry */
-        tmp->remote_event_data = (char *) calloc(1, msg->remote_event_size_bytes);
+        tmp->remote_event_data = (char *)calloc(1, msg->remote_event_size_bytes);
         assert(tmp->remote_event_data);
         tmp->remote_event_size = msg->remote_event_size_bytes;
         memcpy(tmp->remote_event_data, m_data_src, msg->remote_event_size_bytes);
     }
-    if (s->min_latency > tw_now(lp) - msg->travel_start_time) {
+    if (s->min_latency > tw_now(lp) - msg->travel_start_time)
+    {
         s->min_latency = tw_now(lp) - msg->travel_start_time;
     }
 
-    if (s->max_latency < tw_now(lp) - msg->travel_start_time) {
+    if (s->max_latency < tw_now(lp) - msg->travel_start_time)
+    {
         bf->c22 = 1;
         msg->saved_available_time = s->max_latency;
         s->max_latency = tw_now(lp) - msg->travel_start_time;
@@ -4144,7 +4174,8 @@ static void packet_arrive(terminal_state *s, tw_bf *bf, terminal_plus_message *m
      * callee*/
     // assert(tmp->num_chunks <= total_chunks);
 
-    if (tmp->num_chunks >= total_chunks) {
+    if (tmp->num_chunks >= total_chunks)
+    {
         bf->c7 = 1;
 
         s->data_size_sample += msg->total_size;
@@ -4156,7 +4187,8 @@ static void packet_arrive(terminal_state *s, tw_bf *bf, terminal_plus_message *m
         s->finished_msgs++;
 
         // assert(tmp->remote_event_data && tmp->remote_event_size > 0);
-        if (tmp->remote_event_data && tmp->remote_event_size > 0) {
+        if (tmp->remote_event_data && tmp->remote_event_size > 0)
+        {
             bf->c8 = 1;
             send_remote_event(s, msg, lp, bf, tmp->remote_event_data, tmp->remote_event_size);
         }
@@ -4173,14 +4205,15 @@ static void terminal_buf_update_rc(terminal_state *s, tw_bf *bf, terminal_plus_m
     int vcg = 0;
     int num_qos_levels = s->params->num_qos_levels;
 
-    for(int i = 0; i < msg->num_cll; i++)
-       codes_local_latency_reverse(lp);
+    for (int i = 0; i < msg->num_cll; i++)
+        codes_local_latency_reverse(lp);
 
-    if(num_qos_levels > 1)
-      vcg = get_vcg_from_category(msg);
-      
+    if (num_qos_levels > 1)
+        vcg = get_vcg_from_category(msg);
+
     s->vc_occupancy[msg->rail_id][vcg] += s->params->chunk_size;
-    if (bf->c1) {
+    if (bf->c1)
+    {
         s->in_send_loop[msg->rail_id] = 0;
     }
     return;
@@ -4190,23 +4223,24 @@ static void terminal_buf_update(terminal_state *s, tw_bf *bf, terminal_plus_mess
 {
     msg->num_cll = 0;
     msg->num_rngs = 0;
-    
+
     bf->c1 = 0;
     bf->c2 = 0;
     bf->c3 = 0;
     int vcg = 0;
 
-    if(s->params->num_qos_levels > 1)
-      vcg = get_vcg_from_category(msg);
+    if (s->params->num_qos_levels > 1)
+        vcg = get_vcg_from_category(msg);
 
     msg->num_cll++;
     tw_stime ts = codes_local_latency(lp);
     s->vc_occupancy[msg->rail_id][vcg] -= s->params->chunk_size;
 
-    if(s->in_send_loop[msg->rail_id] == 0 && s->terminal_msgs[msg->rail_id][vcg] != NULL) {
+    if (s->in_send_loop[msg->rail_id] == 0 && s->terminal_msgs[msg->rail_id][vcg] != NULL)
+    {
         terminal_plus_message *m;
         bf->c1 = 1;
-        tw_event *e = model_net_method_event_new(lp->gid, ts, lp, DRAGONFLY_PLUS, (void **) &m, NULL);
+        tw_event *e = model_net_method_event_new(lp->gid, ts, lp, DRAGONFLY_PLUS, (void **)&m, NULL);
         m->rail_id = msg->rail_id;
         m->type = T_SEND;
         m->magic = terminal_magic_num;
@@ -4218,28 +4252,29 @@ static void terminal_buf_update(terminal_state *s, tw_bf *bf, terminal_plus_mess
 
 void dragonfly_plus_terminal_final(terminal_state *s, tw_lp *lp)
 {
-    dragonfly_total_time += s->total_time; //increment the PE level time counter
+    dragonfly_total_time += s->total_time; // increment the PE level time counter
 
     if (s->max_latency > dragonfly_max_latency)
-        dragonfly_max_latency = s->max_latency; //get maximum latency across all LPs on this PE
+        dragonfly_max_latency = s->max_latency; // get maximum latency across all LPs on this PE
 
     model_net_print_stats(lp->gid, s->dragonfly_stats_array);
 
     int written = 0;
-    if (s->terminal_id == 0) {
+    if (s->terminal_id == 0)
+    {
         written += sprintf(s->output_buf + written, "# Format <source_id> <source_type> <dest_id> < dest_type>  <link_type> <link_traffic> <link_saturation> <stalled_chunks>\n");
     }
     // written += sprintf(s->output_buf + written, "%u %s %u %s %s %llu %lf %lu\n",
     //     s->terminal_id, "T", s->router_id, "R", "CN", LLU(s->total_msg_size), s->busy_time, s->stalled_chunks);
 
-    for(int i = 0; i < s->params->num_rails; i++)
+    for (int i = 0; i < s->params->num_rails; i++)
     {
-        //since LLU(s->total_msg_size) is total message size a terminal received from a router so source is router and destination is terminal
+        // since LLU(s->total_msg_size) is total message size a terminal received from a router so source is router and destination is terminal
         written += sprintf(s->output_buf + written, "%u %s %u %s %s %llu %lf %lu\n",
-                        s->terminal_id, "T",s->router_id[i], "R","CN", LLU(s->link_traffic[i]), s->busy_time[i], s->stalled_chunks[i]);
+                           s->terminal_id, "T", s->router_id[i], "R", "CN", LLU(s->link_traffic[i]), s->busy_time[i], s->stalled_chunks[i]);
     }
 
-    lp_io_write(lp->gid, (char*)"dragonfly-plus-local-link-stats", written, s->output_buf);
+    lp_io_write(lp->gid, (char *)"dragonfly-plus-local-link-stats", written, s->output_buf);
 
     // if (s->terminal_id == 0) {
     //     char meta_filename[64];
@@ -4253,33 +4288,32 @@ void dragonfly_plus_terminal_final(terminal_state *s, tw_lp *lp)
     // if (s->terminal_id == 0)
     //     written += sprintf(s->output_buf2 + written, "# Format <LP id> <Terminal ID> <recvd_msgs> <recvd_chunks> <recvd_packet> <Total Msg. Latency> <Avg Msg Latency> <busy time> <Avg hops/chunks>\n" );
 
-    // written += sprintf(s->output_buf2 + written, "%llu %llu %ld %ld %ld %lf %lf %lf %lf\n", 
-    //         LLU(lp->gid), LLU(s->terminal_id), s->finished_msgs, s->finished_chunks, s->finished_packets, s->total_time, s->total_time/s->finished_msgs, 
+    // written += sprintf(s->output_buf2 + written, "%llu %llu %ld %ld %ld %lf %lf %lf %lf\n",
+    //         LLU(lp->gid), LLU(s->terminal_id), s->finished_msgs, s->finished_chunks, s->finished_packets, s->total_time, s->total_time/s->finished_msgs,
     //         s->busy_time, (double)s->total_hops/s->finished_chunks);
 
     written = 0;
-    if(s->terminal_id == 0)
+    if (s->terminal_id == 0)
     {
         written += sprintf(s->output_buf2 + written, "# Format <LP id> <Terminal ID> <Total Data Sent> <Total Data Received> <Avg packet latency> <Max packet Latency> <Min packet Latency> <# Packets finished> <Avg Hops> <Avg Busy Time (over rails)>\n");
     }
 
     tw_stime avg_busy_time = 0;
-    for(int i = 0; i < s->params->num_rails; i++)
+    for (int i = 0; i < s->params->num_rails; i++)
         avg_busy_time += s->busy_time[i];
     avg_busy_time = avg_busy_time / s->params->num_rails;
 
-    written += sprintf(s->output_buf2 + written, "%llu %u %d %llu %lf %lf %lf %ld %lf %lf\n", 
-            LLU(lp->gid), s->terminal_id, s->total_gen_size, LLU(s->total_msg_size), s->total_time/s->finished_chunks, s->max_latency, s->min_latency,
-            s->finished_packets, (double)s->total_hops/s->finished_chunks, avg_busy_time);
-   
+    written += sprintf(s->output_buf2 + written, "%llu %u %d %llu %lf %lf %lf %ld %lf %lf\n",
+                       LLU(lp->gid), s->terminal_id, s->total_gen_size, LLU(s->total_msg_size), s->total_time / s->finished_chunks, s->max_latency, s->min_latency,
+                       s->finished_packets, (double)s->total_hops / s->finished_chunks, avg_busy_time);
+
     // written = 0;
-    // written += sprintf(s->output_buf2 + written, "%llu %u %lf %lf %lf %lf %ld %lf\n", 
-    //         LLU(lp->gid), s->terminal_id, s->total_time/s->finished_chunks, 
+    // written += sprintf(s->output_buf2 + written, "%llu %u %lf %lf %lf %lf %ld %lf\n",
+    //         LLU(lp->gid), s->terminal_id, s->total_time/s->finished_chunks,
     //         s->busy_time, s->max_latency, s->min_latency,
     //         s->finished_packets, (double)s->total_hops/s->finished_chunks);
 
-
-    lp_io_write(lp->gid, (char*)"dragonfly-plus-cn-stats", written, s->output_buf2); 
+    lp_io_write(lp->gid, (char *)"dragonfly-plus-cn-stats", written, s->output_buf2);
 
     // if (s->terminal_id == 0) {
     //     char meta_filename[64];
@@ -4301,8 +4335,8 @@ void dragonfly_plus_terminal_final(terminal_state *s, tw_lp *lp)
 
     for(int i = 0; i < s->params->num_rails; i++)
     {
-        if(s->terminal_msgs[i][0] != NULL) 
-        printf("[%llu] leftover terminal messages \n", LLU(lp->gid));
+        if (s->terminal_msgs[i][0] != NULL)
+            printf("[%llu] leftover terminal messages \n", LLU(lp->gid));
     }
 
     // if(s->packet_gen != s->packet_fin)
@@ -4316,6 +4350,9 @@ void dragonfly_plus_terminal_final(terminal_state *s, tw_lp *lp)
     free(s->vc_occupancy);
     free(s->terminal_msgs);
     free(s->terminal_msgs_tail);
+
+    // TODO: drop once make_lptype<T>() trampoline lands.
+    s->connMan.~DragonflyConnectionManager();
 }
 
 void dragonfly_plus_router_final(router_state *s, tw_lp *lp)
@@ -4436,7 +4473,7 @@ void dragonfly_plus_router_final(router_state *s, tw_lp *lp)
                 written2 = sprintf(s->output_buf4, "\n%d %d %d %d %d", s->group_id, s->router_id, i, s->msg_counting[i][0], s->msg_counting[i][1]);
 
                 result=lp_io_write(lp->gid, (char*)"dragonfly-plus-msg-app-id-rec", written2, s->output_buf4);
-                
+
                 if(result!=0)
                     tw_error(TW_LOC, "\nERROR: msg app id i/o failed 2, lpio result %d, svr %llu, lpgid %llu, writting dragonfly-plus-msg-app-id-rec failed, written %d, buf %s, index %d\n", result, LLU(s->router_id), LLU(lp->gid), written2, s->output_buf4, i);
 
@@ -4457,7 +4494,7 @@ void dragonfly_plus_router_final(router_state *s, tw_lp *lp)
     // if (!s->router_id) {
     //     written =
     //         sprintf(s->output_buf, "# Format <Type> <LP ID> <Group ID> <Router ID> <Busy time per router port(s)>");
-    //     written += sprintf(s->output_buf + written, "\n# Router ports in the order: %d Intra Links, %d Inter Links %d Terminal Links. Hyphens for Unconnected ports (No terminals on Spine routers)", p->intra_grp_radix, p->num_global_connections, p->num_cn);  
+    //     written += sprintf(s->output_buf + written, "\n# Router ports in the order: %d Intra Links, %d Inter Links %d Terminal Links. Hyphens for Unconnected ports (No terminals on Spine routers)", p->intra_grp_radix, p->num_global_connections, p->num_cn);
     // }
 
     // char router_type[10];
@@ -4470,7 +4507,7 @@ void dragonfly_plus_router_final(router_state *s, tw_lp *lp)
     // for (int d = 0; d < p->radix; d++) {
     //     bool printed_hyphen = false;
     //     ConnectionType port_type = s->connMan.get_port_type(d);
-        
+
     //     if (port_type == 0) {
     //         written += sprintf(s->output_buf + written, " -");
     //         printed_hyphen = true;
@@ -4486,7 +4523,7 @@ void dragonfly_plus_router_final(router_state *s, tw_lp *lp)
     // if (!s->router_id) {
     //     written =
     //         sprintf(s->output_buf2, "# Format <LP ID> <Group ID> <Router ID> <Busy time per router port(s)>");
-    //     written += sprintf(s->output_buf2 + written, "\n# Router ports in the order: %d Intra Links, %d Inter Links %d Terminal Links. Hyphens for Unconnected ports (No terminals on Spine routers)", p->intra_grp_radix, p->num_global_connections, p->num_cn);  
+    //     written += sprintf(s->output_buf2 + written, "\n# Router ports in the order: %d Intra Links, %d Inter Links %d Terminal Links. Hyphens for Unconnected ports (No terminals on Spine routers)", p->intra_grp_radix, p->num_global_connections, p->num_cn);
     // }
     // written += sprintf(s->output_buf2 + written, "\n%s %llu %d %d", router_type, LLU(lp->gid), s->router_id / p->num_routers, s->router_id % p->num_routers);
 
@@ -4506,10 +4543,13 @@ void dragonfly_plus_router_final(router_state *s, tw_lp *lp)
 
     // if (!g_tw_mynode) {
     //     if (s->router_id == 0) {
-    //         if (PRINT_CONFIG) 
+    //         if (PRINT_CONFIG)
     //             dragonfly_plus_print_params(s->params);
     //     }
     // }
+
+    // TODO: drop once make_lptype<T>() trampoline lands.
+    s->connMan.~DragonflyConnectionManager();
 }
 
 static Connection do_dfp_routing(router_state *s, tw_bf *bf, terminal_plus_message *msg, tw_lp *lp, int fdest_router_id)
@@ -4527,7 +4567,7 @@ static Connection do_dfp_routing(router_state *s, tw_bf *bf, terminal_plus_messa
             vector< Connection > poss_next_stops = s->connMan.get_connections_to_gid(msg->dfp_dest_terminal_id, CONN_TERMINAL);
             if (poss_next_stops.size() < 1)
                 tw_error(TW_LOC, "Destination Router: No Connection to destination terminal\n");
-            
+
             Connection best_min_conn = get_absolute_best_connection_from_conns(s, bf, msg, lp, poss_next_stops);
             return best_min_conn;
         }
@@ -4535,7 +4575,7 @@ static Connection do_dfp_routing(router_state *s, tw_bf *bf, terminal_plus_messa
             vector< Connection > poss_next_stops = get_legal_minimal_stops(s, bf, msg, lp, fdest_router_id);
             if (poss_next_stops.size() < 1)
                 tw_error(TW_LOC, "DEAD END WHEN ROUTING LOCALLY - My Router ID: %d    FDest Router ID: %d (origin router ID: %d)\n", my_router_id, fdest_router_id, msg->origin_router_id);
-            
+
             Connection best_min_conn = get_absolute_best_connection_from_conns(s, bf, msg, lp, poss_next_stops);
             return best_min_conn;
         }
@@ -4668,7 +4708,7 @@ static void router_credit_send(router_state *s, terminal_plus_message *msg, tw_l
     else if (msg->last_hop == GLOBAL) {
         dest = msg->intm_lp_id;
         credit_delay = p->global_credit_delay;
-    }    
+    }
     else if (msg->last_hop == LOCAL) {
         dest = msg->intm_lp_id;
         credit_delay = p->local_credit_delay;
@@ -4710,12 +4750,12 @@ static void router_packet_receive_rc(router_state *s, tw_bf *bf, terminal_plus_m
 {
     router_rev_ecount++;
     router_ecount--;
-    
+
     int output_port = msg->saved_vc;
     int output_chan = msg->saved_channel;
     int dest_gid = msg->dfp_dest_terminal_id / (s->params->total_terminals / s->params->total_groups);
     int inter_group_transmit = 0;
-    
+
     //rc for msg app id counting
     if(dest_gid != s->group_id)
         inter_group_transmit = 1;
@@ -4771,12 +4811,12 @@ static void router_packet_receive(router_state *s, tw_bf *bf, terminal_plus_mess
 {
     msg->num_cll = 0;
     msg->num_rngs = 0;
-    
+
     router_verify_valid_receipt(s, bf, msg, lp);
     router_ecount++;
 
     tw_stime ts;
-  
+
     int num_qos_levels = s->params->num_qos_levels;
     int vcs_per_qos = s->params->num_vcs / num_qos_levels;
 
@@ -4786,9 +4826,9 @@ static void router_packet_receive(router_state *s, tw_bf *bf, terminal_plus_mess
         msg->num_cll++;
         tw_stime bw_ts = bw_reset_window + codes_local_latency(lp);
         terminal_plus_message * m;
-        tw_event * e = model_net_method_event_new(lp->gid, bw_ts, lp, 
-             DRAGONFLY_PLUS_ROUTER, (void**)&m, NULL); 
-        m->type = R_BANDWIDTH; 
+        tw_event *e = model_net_method_event_new(lp->gid, bw_ts, lp,
+                                                 DRAGONFLY_PLUS_ROUTER, (void **)&m, NULL);
+        m->type = R_BANDWIDTH;
         m->magic = router_magic_num;
         tw_event_send(e);
         s->is_monitoring_bw = 1;
@@ -4797,9 +4837,8 @@ static void router_packet_receive(router_state *s, tw_bf *bf, terminal_plus_mess
     if(num_qos_levels > 1)
       vcg = get_vcg_from_category(msg);
 
-
-    //MSG COUNTING SPECIFIC -------
-    //If spine router, count how many packets I have received & identify their app id 
+    // MSG COUNTING SPECIFIC -------
+    // If spine router, count how many packets I have received & identify their app id
     msg->last_received_time = tw_now(lp);
 
     int fdest_group_id = msg->dfp_dest_terminal_id / (s->params->total_terminals / s->params->total_groups);
@@ -4873,7 +4912,7 @@ static void router_packet_receive(router_state *s, tw_bf *bf, terminal_plus_mess
     }
     else
         tw_error(TW_LOC, "upward channel flag has invalid value\n");
-  
+
     assert(output_chan < vcs_per_qos);
     output_chan = output_chan + (vcg * vcs_per_qos);
 
@@ -4976,62 +5015,66 @@ static void router_packet_send_rc(router_state *s, tw_bf *bf, terminal_plus_mess
 {
     router_ecount--;
     router_rev_ecount++;
-    
+
     int num_qos_levels = s->params->num_qos_levels;
     int output_port = msg->saved_vc;
-      
+
     if(msg->qos_reset1)
           s->qos_status[output_port][0] = Q_ACTIVE;
      if(msg->qos_reset2)
           s->qos_status[output_port][1] = Q_ACTIVE;
-    
+
     if(msg->last_saved_qos)
-       s->last_qos_lvl[output_port] = msg->last_saved_qos; 
-     
-    if(bf->c1) {
+        s->last_qos_lvl[output_port] = msg->last_saved_qos;
+
+    if (bf->c1)
+    {
         s->in_send_loop[output_port] = 1;
-        if(bf->c2) {
+        if (bf->c2)
+        {
             s->last_buf_full[output_port] = msg->saved_busy_time;
         }
-        return;  
+        return;
     }
-   
-    for(int i = 0; i < msg->num_rngs; i++)
+
+    for (int i = 0; i < msg->num_rngs; i++)
         tw_rand_reverse_unif(lp->rng);
 
-   for(int i = 0; i < msg->num_cll; i++)
-       codes_local_latency_reverse(lp);
-   
-   int output_chan = msg->saved_channel;
-   if(bf->c8)
+    for (int i = 0; i < msg->num_cll; i++)
+        codes_local_latency_reverse(lp);
+
+    int output_chan = msg->saved_channel;
+    if (bf->c8)
     {
         s->busy_time[output_port] = msg->saved_rcv_time;
         s->busy_time_sample[output_port] = msg->saved_sample_time;
         s->ross_rsample.busy_time[output_port] = msg->saved_sample_time;
         s->last_buf_full[output_port] = msg->saved_busy_time;
-   }
+    }
 
-    terminal_plus_message_list *cur_entry = (terminal_plus_message_list *) rc_stack_pop(s->st);
+    terminal_plus_message_list *cur_entry = (terminal_plus_message_list *)rc_stack_pop(s->st);
     assert(cur_entry);
-    
+
     int vcg = 0;
     if (num_qos_levels > 1)
         vcg = get_vcg_from_category(&(cur_entry->msg));
 
     int msg_size = s->params->chunk_size;
-    if(cur_entry->msg.packet_size < s->params->chunk_size)
+    if (cur_entry->msg.packet_size < s->params->chunk_size)
         msg_size = cur_entry->msg.packet_size;
 
     s->qos_data[output_port][vcg] -= msg_size;
     s->next_output_available_time[output_port] = msg->saved_available_time;
 
-    if (bf->c11) {
+    if (bf->c11)
+    {
         s->link_traffic[output_port] -= cur_entry->msg.packet_size % s->params->chunk_size;
         s->link_traffic_sample[output_port] -= cur_entry->msg.packet_size % s->params->chunk_size;
         s->ross_rsample.link_traffic_sample[output_port] -= cur_entry->msg.packet_size % s->params->chunk_size;
         s->link_traffic_ross_sample[output_port] -= cur_entry->msg.packet_size % s->params->chunk_size;
     }
-    if (bf->c12) {
+    if (bf->c12)
+    {
         s->link_traffic[output_port] -= s->params->chunk_size;
         s->link_traffic_sample[output_port] -= s->params->chunk_size;
         s->ross_rsample.link_traffic_sample[output_port] -= s->params->chunk_size;
@@ -5041,7 +5084,8 @@ static void router_packet_send_rc(router_state *s, tw_bf *bf, terminal_plus_mess
     prepend_to_terminal_plus_message_list(s->pending_msgs[output_port], s->pending_msgs_tail[output_port],
                                           output_chan, cur_entry);
 
-    if (bf->c4) {
+    if (bf->c4)
+    {
         s->in_send_loop[output_port] = 1;
     }
 }
@@ -5067,34 +5111,35 @@ static void router_packet_send(router_state *s, tw_bf *bf, terminal_plus_message
     msg->num_rngs = 0;
 
     int num_qos_levels = s->params->num_qos_levels;
-    int output_chan = get_next_router_vcg(s, bf, msg, lp); //includes default output_chan setting functionality
+    int output_chan = get_next_router_vcg(s, bf, msg, lp); // includes default output_chan setting functionality
 
     msg->saved_vc = output_port;
     msg->saved_channel = output_chan;
-  
-    if(output_chan < 0) {
-      bf->c1 = 1;
-      s->in_send_loop[output_port] = 0;
-      if(s->queued_count[output_port] && !s->last_buf_full[output_port]) //10-31-19, not sure why this was added here with the qos stuff
-      {
-        bf->c2 = 1; 
-        msg->saved_busy_time = s->last_buf_full[output_port];
-        s->last_buf_full[output_port] = tw_now(lp);
-      }  
-      return;
+
+    if (output_chan < 0)
+    {
+        bf->c1 = 1;
+        s->in_send_loop[output_port] = 0;
+        if (s->queued_count[output_port] && !s->last_buf_full[output_port]) // 10-31-19, not sure why this was added here with the qos stuff
+        {
+            bf->c2 = 1;
+            msg->saved_busy_time = s->last_buf_full[output_port];
+            s->last_buf_full[output_port] = tw_now(lp);
+        }
+        return;
     }
-  
+
     cur_entry = s->pending_msgs[output_port][output_chan];
- 
+
     assert(cur_entry != NULL);
-  
+
     if(s->last_buf_full[output_port]) //10-31-19, same here as above comment
     {
       bf->c8 = 1;
-      msg->saved_rcv_time = s->busy_time[output_port]; 
-      msg->saved_busy_time = s->last_buf_full[output_port]; 
-      msg->saved_sample_time = s->busy_time_sample[output_port];  
-      s->busy_time[output_port] += (tw_now(lp) - s->last_buf_full[output_port]); 
+      msg->saved_rcv_time = s->busy_time[output_port];
+      msg->saved_busy_time = s->last_buf_full[output_port];
+      msg->saved_sample_time = s->busy_time_sample[output_port];
+      s->busy_time[output_port] += (tw_now(lp) - s->last_buf_full[output_port]);
       s->busy_time_sample[output_port] += (tw_now(lp) - s->last_buf_full[output_port]);
       s->ross_rsample.busy_time[output_port] += (tw_now(lp) - s->last_buf_full[output_port]);
       s->last_buf_full[output_port] = 0.0;
@@ -5201,11 +5246,11 @@ static void router_packet_send(router_state *s, tw_bf *bf, terminal_plus_message
     cur_entry = return_head(s->pending_msgs[output_port], s->pending_msgs_tail[output_port], output_chan);
     rc_stack_push(lp, cur_entry, delete_terminal_plus_message_list, s->st);
 
-    s->qos_data[output_port][vcg] += msg_size; 
+    s->qos_data[output_port][vcg] += msg_size;
     s->next_output_available_time[output_port] -= s->params->router_delay;
     ts -= s->params->router_delay;
 
-    int next_output_chan = get_next_router_vcg(s, bf, msg, lp); 
+    int next_output_chan = get_next_router_vcg(s, bf, msg, lp);
 
     if(next_output_chan < 0)
     {
@@ -5214,7 +5259,7 @@ static void router_packet_send(router_state *s, tw_bf *bf, terminal_plus_message
       return;
     }
     cur_entry = s->pending_msgs[output_port][next_output_chan];
-    assert(cur_entry != NULL); 
+    assert(cur_entry != NULL);
 
     terminal_plus_message *m_new;
     msg->num_rngs++;
@@ -5225,7 +5270,7 @@ static void router_packet_send(router_state *s, tw_bf *bf, terminal_plus_message
     m_new->magic = router_magic_num;
     m_new->vc_index = output_port;
     tw_event_send(e);
-    
+
     return;
 }
 
@@ -5234,13 +5279,13 @@ static void router_buf_update_rc(router_state *s, tw_bf *bf, terminal_plus_messa
     int indx = msg->vc_index;
     int output_chan = msg->output_chan;
     s->vc_occupancy[indx][output_chan] += s->params->chunk_size;
-      
+
     for(int i = 0; i < msg->num_rngs; i++)
         tw_rand_reverse_unif(lp->rng);
 
     for(int i = 0; i < msg->num_cll; i++)
        codes_local_latency_reverse(lp);
-    
+
     if (bf->c3) {
         s->busy_time[indx] = msg->saved_rcv_time;
         s->busy_time_sample[indx] = msg->saved_sample_time;
@@ -5333,7 +5378,7 @@ void terminal_plus_event(terminal_state *s, tw_bf *bf, terminal_plus_message *ms
         case T_BUFFER:
             terminal_buf_update(s, bf, msg, lp);
             break;
-        
+
         case T_BANDWIDTH:
             issue_bw_monitor_event_rc(s, bf, msg, lp);
             break;
@@ -5423,7 +5468,7 @@ void router_plus_rc_event_handler(router_state *s, tw_bf *bf, terminal_plus_mess
         case R_BUFFER:
             router_buf_update_rc(s, bf, msg, lp);
             break;
-        
+
         case R_BANDWIDTH:
             issue_rtr_bw_monitor_event_rc(s, bf, msg, lp);
             break;
@@ -5519,7 +5564,7 @@ static void router_plus_register(tw_lptype *base_type)
 //             // }
 //             // else
 //             //     return poss_next_stops[0];
-        
+
 //         Connection best_min_conn = get_absolute_best_connection_from_conns(s, bf, msg, lp, poss_next_stops);
 //         return best_min_conn;
 //     }
@@ -5527,7 +5572,7 @@ static void router_plus_register(tw_lptype *base_type)
 //         vector< Connection > poss_next_stops = get_legal_minimal_stops(s, bf, msg, lp, fdest_router_id);
 //         if (poss_next_stops.size() < 1)
 //             tw_error(TW_LOC, "DEAD END WHEN ROUTING LOCALLY - My Router ID: %d    FDest Router ID: %d (origin router ID: %d)\n", my_router_id, fdest_router_id, msg->origin_router_id);
-        
+
 //         Connection best_min_conn = get_absolute_best_connection_from_conns(s, bf, msg, lp, poss_next_stops);
 //         return best_min_conn;
 //     }
@@ -5590,12 +5635,11 @@ static void router_plus_register(tw_lptype *base_type)
 //         vector< Connection > poss_min_next_stops = get_legal_minimal_stops(s, bf, msg, lp, fdest_router_id);
 //         vector< Connection > poss_intm_next_stops = get_legal_nonminimal_stops(s, bf, msg, lp, fdest_router_id);
 
-
 //         vector< Connection > poss_next_stops;
 //         if (route_to_fdest) {
 //             poss_next_stops = poss_min_next_stops;
 //             if (poss_next_stops.size() < 1)
-//                 tw_error(TW_LOC, "Dead end when finding stops to fdest router");            
+//                 tw_error(TW_LOC, "Dead end when finding stops to fdest router");
 //         }
 //         else { //then we need to be going toward the intermediate router
 //             msg->path_type = NON_MINIMAL;
@@ -5614,7 +5658,7 @@ static void router_plus_register(tw_lptype *base_type)
 
 //         if (best_conn.port == -1)
 //             tw_error(TW_LOC, "Get best Connection returned a bad Connection");
-        
+
 //         return best_conn;
 //     }
 
@@ -5633,42 +5677,48 @@ static int get_min_hops_to_dest_from_conn(router_state *s, tw_bf *bf, terminal_p
     if (msg->dfp_upward_channel_flag)
     {
         if (my_type == SPINE)
-            return 2; //Next Spine -> Leaf -> dest_term
+            return 2; // Next Spine -> Leaf -> dest_term
         else
-            return 3; //Next Spine -> Spine -> Leaf -> dest_term
+            return 3; // Next Spine -> Spine -> Leaf -> dest_term
     }
 
-    if(conn.dest_group_id == fdest_group_id) {
+    if (conn.dest_group_id == fdest_group_id)
+    {
         if (next_hops_type == SPINE)
-            return 2; //Next Spine -> Leaf -> dest_term
-        else {
+            return 2; // Next Spine -> Leaf -> dest_term
+        else
+        {
             assert(next_hops_type == LEAF);
-            return 1; //Next Leaf -> dest_term
+            return 1; // Next Leaf -> dest_term
         }
     }
-    else { //next is not in final destination group
-        if (next_hops_type == SPINE) {
-            vector< Connection > cons_to_dest_group = netMan.get_connection_manager_for_router(conn.dest_gid).get_connections_to_group(fdest_group_id);
+    else
+    { // next is not in final destination group
+        if (next_hops_type == SPINE)
+        {
+            vector<Connection> cons_to_dest_group = netMan.get_connection_manager_for_router(conn.dest_gid).get_connections_to_group(fdest_group_id);
             if (cons_to_dest_group.size() == 0)
-                return 5; //Next Spine -> Leaf -> Spine -> Spine -> Leaf -> dest_term
+                return 5; // Next Spine -> Leaf -> Spine -> Spine -> Leaf -> dest_term
             else
-                return 3;  //Next Spine -> Spine -> Leaf -> dest_term
+                return 3; // Next Spine -> Spine -> Leaf -> dest_term
         }
-        else {
+        else
+        {
             assert(next_hops_type == LEAF);
-            return 4; //Next Leaf -> Spine -> Spine -> Leaf -> dest_term
+            return 4; // Next Leaf -> Spine -> Spine -> Leaf -> dest_term
         }
     }
 }
 
-//usded by FPAR, compare each port score with T, if muliples are <= T, choose a random one
+// usded by FPAR, compare each port score with T, if muliples are <= T, choose a random one
 static Connection get_connection_compare_T(router_state *s, tw_bf *bf, terminal_plus_message *msg, tw_lp *lp, vector<Connection> conns, int threshold)
 {
-    assert(threshold>=0 && threshold<=100);
+    assert(threshold >= 0 && threshold <= 100);
     int origin_group_id = msg->origin_router_id / s->params->num_routers;
     int my_group_id = s->router_id / s->params->num_routers;
 
-    if (conns.size() == 0) {
+    if (conns.size() == 0)
+    {
         Connection bad_conn;
         bad_conn.src_gid = -1;
         bad_conn.port = -1;
@@ -5682,49 +5732,55 @@ static Connection get_connection_compare_T(router_state *s, tw_bf *bf, terminal_
 
     vector<int> best_indexes;
 
-    if (scoring_preference == LOWER) {
-        for(int i = 0; i < num_to_compare; i++)
-            {
-                scores[i] = dfp_score_connection(s, bf, msg, lp, conns[i], C_MIN);
-                if (scores[i] <= threshold)
-                    best_indexes.push_back(i);
-                //if(my_group_id==0 && s->dfp_router_type==SPINE && num_to_compare == 2) printf("\tCompare T: Router %d, to port: %d, score %d\n", s->router_id, conns[i].port, scores[i]);
-            }
-            if (best_indexes.size() > 0) {
-                msg->num_rngs++;
-                best_score_index = best_indexes[tw_rand_ulong(lp->rng, 0, best_indexes.size()-1)];
-            } else {
-                //no high priority queue < T
-                Connection bad_conn2;
-                bad_conn2.src_gid = -2;
-                bad_conn2.port = -2;
-                return bad_conn2;
-            }
+    if (scoring_preference == LOWER)
+    {
+        for (int i = 0; i < num_to_compare; i++)
+        {
+            scores[i] = dfp_score_connection(s, bf, msg, lp, conns[i], C_MIN);
+            if (scores[i] <= threshold)
+                best_indexes.push_back(i);
+            // if(my_group_id==0 && s->dfp_router_type==SPINE && num_to_compare == 2) printf("\tCompare T: Router %d, to port: %d, score %d\n", s->router_id, conns[i].port, scores[i]);
+        }
+        if (best_indexes.size() > 0)
+        {
+            msg->num_rngs++;
+            best_score_index = best_indexes[tw_rand_ulong(lp->rng, 0, best_indexes.size() - 1)];
+        }
+        else
+        {
+            // no high priority queue < T
+            Connection bad_conn2;
+            bad_conn2.src_gid = -2;
+            bad_conn2.port = -2;
+            return bad_conn2;
+        }
     }
-    else 
+    else
         tw_error(TW_LOC, "Higher scoring preference currently not implemented for PFAR");
 
-    //if(origin_group_id==0 && s->dfp_router_type==SPINE) printf("\t\tCompare T: Router %d, among size %lu, choose index: %d \n", s->router_id, best_indexes.size(), best_score_index);
+    // if(origin_group_id==0 && s->dfp_router_type==SPINE) printf("\t\tCompare T: Router %d, among size %lu, choose index: %d \n", s->router_id, best_indexes.size(), best_score_index);
 
     return conns[best_score_index];
 }
 
-//give the vector of all routers attached with global link(s) in current group, used by get_legal_nonminimal_stops
-static vector< Connection > get_router_with_global_links(router_state *s, tw_bf *bf, terminal_plus_message *msg, tw_lp *lp)
+// give the vector of all routers attached with global link(s) in current group, used by get_legal_nonminimal_stops
+static vector<Connection> get_router_with_global_links(router_state *s, tw_bf *bf, terminal_plus_message *msg, tw_lp *lp)
 {
-    vector< Connection> spine_with_global_link;
+    vector<Connection> spine_with_global_link;
     set<int> poss_router_id_set_to_group;
     int my_group_id = s->router_id / s->params->num_routers;
 
-    for(int desg=0; desg< s->params->total_groups; desg++) {
+    for (int desg = 0; desg < s->params->total_groups; desg++)
+    {
         vector<int> global_connected_gids = s->connMan.get_router_gids_with_global_to_group(desg);
 
-        for(int i = 0; i < global_connected_gids.size(); i++)
+        for (int i = 0; i < global_connected_gids.size(); i++)
         {
             int poss_router_id = global_connected_gids[i];
             // printf("%d\n",poss_router_id);
-            if (poss_router_id_set_to_group.count(poss_router_id) == 0) { //if we haven't added the connections from poss_router_id yet
-                vector< Connection > conns = s->connMan.get_connections_to_gid(poss_router_id, CONN_LOCAL);
+            if (poss_router_id_set_to_group.count(poss_router_id) == 0)
+            { // if we haven't added the connections from poss_router_id yet
+                vector<Connection> conns = s->connMan.get_connections_to_gid(poss_router_id, CONN_LOCAL);
                 poss_router_id_set_to_group.insert(poss_router_id);
                 spine_with_global_link.insert(spine_with_global_link.end(), conns.begin(), conns.end());
             }
@@ -5739,34 +5795,39 @@ static void dfp_select_intermediate_group(router_state *s, tw_bf *bf, terminal_p
     int origin_group_id = msg->origin_router_id / s->params->num_routers;
 
     // Has an intermediate group been chosen yet? (Should happen at first router)
-    if (msg->intm_grp_id == -1) { // Intermediate group hasn't been chosen yet, choose one randomly and route toward it
+    if (msg->intm_grp_id == -1)
+    { // Intermediate group hasn't been chosen yet, choose one randomly and route toward it
         assert(s->router_id == msg->origin_router_id);
         msg->num_rngs++;
         int rand_group_id;
-        if (NONMIN_INCLUDE_SOURCE_DEST) //then any group is a valid intermediate group
-            rand_group_id = tw_rand_integer(lp->rng, s->params->num_groups*s->plane_id, (s->params->num_groups*(s->plane_id+1))-1);
-        else { //then we don't consider source or dest groups as valid intermediate groups
+        if (NONMIN_INCLUDE_SOURCE_DEST) // then any group is a valid intermediate group
+            rand_group_id = tw_rand_integer(lp->rng, s->params->num_groups * s->plane_id, (s->params->num_groups * (s->plane_id + 1)) - 1);
+        else
+        { // then we don't consider source or dest groups as valid intermediate groups
             vector<int> group_list;
-            for (int i = s->params->num_groups*s->plane_id; i < s->params->num_groups*(s->plane_id+1); i++)
+            for (int i = s->params->num_groups * s->plane_id; i < s->params->num_groups * (s->plane_id + 1); i++)
             {
-                if ((i != origin_group_id) && (i != fdest_group_id)) {
+                if ((i != origin_group_id) && (i != fdest_group_id))
+                {
                     group_list.push_back(i);
                 }
             }
-            int rand_sel = tw_rand_integer(lp->rng, 0, group_list.size()-1);
+            int rand_sel = tw_rand_integer(lp->rng, 0, group_list.size() - 1);
             rand_group_id = group_list[rand_sel];
         }
         msg->intm_grp_id = rand_group_id;
     }
-    else { //the only time that it is re-set is when a router didn't have a direct Connection to the intermediate group but had no other options
+    else
+    { // the only time that it is re-set is when a router didn't have a direct Connection to the intermediate group but had no other options
         // so we need to pick an intm group that the current router DOES have a Connection to.
         assert(s->router_id != msg->origin_router_id);
 
-        set< int > valid_intm_groups;
-        vector< Connection > global_conns = s->connMan.get_connections_by_type(CONN_GLOBAL);
-        for (vector<Connection>::iterator it = global_conns.begin(); it != global_conns.end(); it ++) {
+        set<int> valid_intm_groups;
+        vector<Connection> global_conns = s->connMan.get_connections_by_type(CONN_GLOBAL);
+        for (vector<Connection>::iterator it = global_conns.begin(); it != global_conns.end(); it++)
+        {
             Connection conn = *it;
-            if (NONMIN_INCLUDE_SOURCE_DEST) //then any group I connect to is valid
+            if (NONMIN_INCLUDE_SOURCE_DEST) // then any group I connect to is valid
             {
                 valid_intm_groups.insert(conn.dest_group_id);
             }
@@ -5777,17 +5838,17 @@ static void dfp_select_intermediate_group(router_state *s, tw_bf *bf, terminal_p
             }
         }
 
-        int rand_sel = tw_rand_integer(lp->rng, 0, valid_intm_groups.size()-1);
+        int rand_sel = tw_rand_integer(lp->rng, 0, valid_intm_groups.size() - 1);
         msg->num_rngs++;
-        set< int >::iterator it = valid_intm_groups.begin();
-        advance(it, rand_sel); //you can't just use [] to access a set
+        set<int>::iterator it = valid_intm_groups.begin();
+        advance(it, rand_sel); // you can't just use [] to access a set
         msg->intm_grp_id = *it;
     }
 }
 
-//Note this has been updated to no longer be the converse of minimal stops. It now includes any next stops that can get to the intermediate group. This is now in line more with the 1D Dragonfly model.
-//previously nonminimal stops being the converse of minimal was the norm as recommended but it seems to not load balance appropriately.
-static vector< Connection > get_legal_nonminimal_stops(router_state *s, tw_bf *bf, terminal_plus_message *msg, tw_lp *lp, int fdest_router_id)
+// Note this has been updated to no longer be the converse of minimal stops. It now includes any next stops that can get to the intermediate group. This is now in line more with the 1D Dragonfly model.
+// previously nonminimal stops being the converse of minimal was the norm as recommended but it seems to not load balance appropriately.
+static vector<Connection> get_legal_nonminimal_stops(router_state *s, tw_bf *bf, terminal_plus_message *msg, tw_lp *lp, int fdest_router_id)
 {
     int my_router_id = s->router_id;
     int my_group_id = s->router_id / s->params->num_routers;
@@ -5798,12 +5859,15 @@ static vector< Connection > get_legal_nonminimal_stops(router_state *s, tw_bf *b
 
     vector<Connection> poss_next_nonmin_stops;
 
-    if(my_group_id == origin_group_id) {
-        if (s->dfp_router_type == LEAF) {
+    if (my_group_id == origin_group_id)
+    {
+        if (s->dfp_router_type == LEAF)
+        {
             vector<Connection> conns_to_connecting_routers = s->connMan.get_routed_connections_to_group(preset_intm_group_id, true);
             return conns_to_connecting_routers;
         }
-        else if (s->dfp_router_type == SPINE) {
+        else if (s->dfp_router_type == SPINE)
+        {
             vector<Connection> conns_to_group = s->connMan.get_connections_to_group(preset_intm_group_id);
             if (conns_to_group.size() < 1)
             {
@@ -5814,14 +5878,18 @@ static vector< Connection > get_legal_nonminimal_stops(router_state *s, tw_bf *b
             return conns_to_group;
         }
     }
-    if(in_intermediate_group) {
-        if (msg->dfp_upward_channel_flag == 1) {
+    if (in_intermediate_group)
+    {
+        if (msg->dfp_upward_channel_flag == 1)
+        {
             return poss_next_nonmin_stops;
         }
-        else if (s->dfp_router_type == LEAF) { //if we're a leaf in an intermediate group then the routing alg should have flipped the dfp_upward channel already but lets return empty just in case
+        else if (s->dfp_router_type == LEAF)
+        { // if we're a leaf in an intermediate group then the routing alg should have flipped the dfp_upward channel already but lets return empty just in case
             return poss_next_nonmin_stops;
         }
-        else if (s->dfp_router_type == SPINE) { //then possible_minimal_stops will be the list of connections 
+        else if (s->dfp_router_type == SPINE)
+        { // then possible_minimal_stops will be the list of connections
             assert(msg->dfp_upward_channel_flag == 0);
             vector< Connection> conns_to_leaves = s->connMan.get_connections_by_type(CONN_LOCAL);
             return conns_to_leaves;
@@ -5881,7 +5949,7 @@ static vector< Connection > get_legal_nonminimal_stops(router_state *s, tw_bf *b
 //         if (s->dfp_router_type == LEAF) { //then any connections to spines that are not in possible_minimal_stops should be included
 //             vector< Connection > conns_to_spines = s->connMan.get_connections_by_type(CONN_LOCAL);
 //             possible_nonminimal_stops = set_difference_vectors(conns_to_spines, possible_minimal_stops); //get the complement of possible_minimal_stops
-        
+
 //             // for the case that not all spine routers have global link
 //             vector< Connection > spine_with_global_link = get_router_with_global_links(s, bf, msg, lp);
 //             possible_nonminimal_stops = set_common_vectors(possible_nonminimal_stops, spine_with_global_link);
@@ -5900,7 +5968,7 @@ static vector< Connection > get_legal_nonminimal_stops(router_state *s, tw_bf *b
 //             assert(possible_nonminimal_stops.size() == 0);
 //             return possible_nonminimal_stops;
 //         }
-//         else if (s->dfp_router_type == SPINE) { //then possible_minimal_stops will be the list of connections 
+//         else if (s->dfp_router_type == SPINE) { //then possible_minimal_stops will be the list of connections
 //             assert(msg->dfp_upward_channel_flag == 0);
 //             vector< Connection> conns_to_leaves = s->connMan.get_connections_by_type(CONN_LOCAL);
 //             possible_nonminimal_stops = set_difference_vectors(conns_to_leaves, possible_minimal_stops); //get the complement of possible_minimal_stops
@@ -5980,7 +6048,7 @@ static vector< Connection > get_legal_minimal_stops(router_state *s, tw_bf *bf, 
         }
         else {
             assert(s->dfp_router_type == LEAF);
-            
+
             if (my_router_id != fdest_router_id) { //then we're also the source group and we need to send to any spine in our group
                 assert(my_group_id == origin_group_id);
                 if(netMan.is_link_failures_enabled()) {
@@ -6002,7 +6070,7 @@ static vector< Connection > get_legal_minimal_stops(router_state *s, tw_bf *bf, 
                 vector< Connection > empty;
                 return empty;
             }
-        } 
+        }
     }
     vector< Connection > empty;
     return empty;
@@ -6073,7 +6141,7 @@ static Connection dfp_nonminimal_leaf_routing(router_state *s, tw_bf *bf, termin
 
     if (best_conn.port == -1)
         tw_error(TW_LOC, "Get best Connection returned a bad Connection");
-    
+
     return best_conn;
 }
 
@@ -6202,7 +6270,7 @@ static Connection dfp_fully_prog_adaptive_routing(router_state *s, tw_bf *bf, te
     bool outside_source_group = (my_group_id != origin_group_id);
     int adaptive_threshold = s->params->adaptive_threshold;
 
-    // check FPAR validity: 
+    // check FPAR validity:
     // 1) should use ALPHA scoring, for now
     // 2) threshold within [0-100]
     if (scoring != ALPHA)
@@ -6297,10 +6365,10 @@ static Connection dfp_fully_prog_adaptive_routing(router_state *s, tw_bf *bf, te
             }
 
         } else if (in_intermediate_group) {
-            
+
             if(msg->path_type != NON_MINIMAL) {
                 printf("Error In FPAR: [MSG: %d => %d ]: router %d, type %d, group %d, nextStopgid %d, nextStop_group_id %d\n", msg->dfp_src_terminal_id, msg->dfp_dest_terminal_id, s->router_id, s->dfp_router_type, my_group_id, nextStopConn.dest_gid, nextStopConn.dest_group_id);
-            } 
+            }
 
             if(msg->dfp_upward_channel_flag != 0) {
                 nextStopConn=best_min_conn;
@@ -6403,7 +6471,7 @@ static set<Connection> get_smart_legal_nonminimal_stops(router_state *s, tw_bf *
     int my_group_id = s->group_id;
     int fdest_group_id = fdest_router_id / s->params->num_routers;
     int origin_group_id = msg->origin_router_id / s->params->num_routers;
-    
+
     bool in_intermediate_group = (my_group_id != fdest_group_id && my_group_id != origin_group_id);
 
     set<Connection> possible_next_dests;
@@ -6415,7 +6483,7 @@ static set<Connection> get_smart_legal_nonminimal_stops(router_state *s, tw_bf *
     }
     else {
         possible_next_dests = netMan.get_valid_next_hops_conns(s->router_id, fdest_router_id, (max_hops_per_group-msg->my_hops_cur_group), (max_global_hops_nonminimal-msg->my_g_hop));
-        
+
         //if we havent hit a leaf router yet, we aren't supposed to send along a global link to the dest group if we are in the intermediate group
         if (msg->dfp_upward_channel_flag == 0 && s->dfp_router_type == SPINE && in_intermediate_group)
         {
@@ -6477,7 +6545,7 @@ static Connection dfp_smart_minimal_routing(router_state *s, tw_bf *bf, terminal
         // set<Connection>::iterator it = possible_conns.begin();
         // advance(it, offset);
         // return *(it);
-    }    
+    }
 }
 
 static Connection dfp_smart_nonminimal_routing(router_state *s, tw_bf *bf, terminal_plus_message *msg, tw_lp *lp, int fdest_router_id)
@@ -6505,7 +6573,7 @@ static Connection dfp_smart_nonminimal_routing(router_state *s, tw_bf *bf, termi
     {
         msg->path_type = NON_MINIMAL; //become nonminimal the moment that we're not in the source or dest group
     }
-        
+
     set<Connection> possible_conns = get_smart_legal_nonminimal_stops(s, bf, msg, lp, fdest_router_id);
 
     if (possible_conns.size() < 1)
@@ -6559,7 +6627,7 @@ static Connection dfp_smart_prog_adaptive_routing(router_state *s, tw_bf *bf, te
         return get_absolute_best_connection_from_conn_set(s, bf, msg, lp, poss_min_next_stops);
     }
     else
-    {   
+    {
         if(msg->path_type == NON_MINIMAL) //then we have no choice but to route to the intm router id
         {
             set<Connection> poss_next_stops = get_smart_legal_nonminimal_stops(s, bf, msg, lp, fdest_router_id);


### PR DESCRIPTION
Need a few build fixes before I can start working on the tasks planned for the CODES refactor. 

#240 added a bug in the build where if you aren't building with ZeroMQ support, you get an error about not finding `libzmqmlrequester.so`. I have more build changes coming later, along with CI so we can catch these kinds of things more easily, but need this one now so I can even build without needing zeromq.

Another fix in this PR fixes some test segfaults on Mac. Essentially the DragonflyConnectionManager is in the LP state, but ctors are never called because, so I use placement new to fix that. I suspect this may also fix the non-deterministic test failures in the CODES contract test in ROSS CI, but not 100% sure yet. 

Last fix is that `mempcpy` was being used, but this is not available on Mac (which is what I largely do development on). Since the return value isn't being used, it's the same as using `memcpy` so I just changed it to that. 