### PR TITLE
ci: heavy-deps image for the full CODES CI job

### DIFF
--- a/.github/workflows/full-ci-image.yml
+++ b/.github/workflows/full-ci-image.yml
@@ -1,0 +1,74 @@
+name: Full CI image
+
+# Builds the heavy-dependency image (ci/full/Dockerfile) used by the `full` job
+# in build.yml, and publishes it to GHCR. The slow dependency compiles
+# (argobots, SWM, conceptual, UNION, ZeroMQ, DUMPI, Torch) happen ONCE here
+# instead of on every PR — the `full` job pulls this image and only builds
+# ROSS + CODES inside it.
+#
+# This workflow is deliberately NOT triggered on every PR: the image only needs
+# rebuilding when its recipe changes. It runs on:
+#   * pushes to master that touch the Dockerfile or this workflow,
+#   * a weekly schedule (so base-image security updates get picked up), and
+#   * manual dispatch (the bootstrap path — run this once to publish :latest
+#     before the build.yml `full` job can pull it).
+#
+# Published as ghcr.io/codes-org/codes-ci-full — :latest plus a :<sha> tag so a
+# build.yml change can pin a specific image if a Dockerfile bump regresses.
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'ci/full/Dockerfile'
+      - '.github/workflows/full-ci-image.yml'
+  schedule:
+    # Weekly, Monday 08:00 UTC — refresh the ubuntu:22.04 base + apt packages.
+    - cron: "0 8 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    name: build + push codes-ci-full
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout CODES
+        uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          # The Dockerfile COPYs nothing from the build context (every dependency
+          # is cloned/downloaded inside the build), so the context is just the
+          # directory holding the Dockerfile. `file` defaults to
+          # {context}/Dockerfile = ci/full/Dockerfile.
+          context: ci/full
+          # CI builds amd64 (the runner arch), so APT_MIRROR keeps its empty
+          # default (archive.ubuntu.com). The arm64 APT_MIRROR override documented
+          # in the Dockerfile is for local validation only; torch is pinned to the
+          # CPU wheel index for both arches in the Dockerfile.
+          platforms: linux/amd64
+          # Don't publish from PR builds (a PR can't be trusted with packages:write
+          # and shouldn't move :latest); push only on master / schedule / dispatch.
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: |
+            ghcr.io/codes-org/codes-ci-full:latest
+            ghcr.io/codes-org/codes-ci-full:${{ github.sha }}
+          # Persist layer cache between runs so an unchanged Dockerfile is a fast
+          # no-op and a one-line bump only rebuilds the affected layer onward.
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/ci/full/Dockerfile
+++ b/ci/full/Dockerfile
@@ -1,0 +1,142 @@
+# Heavy-dependency image for the CODES "full" CI job.
+#
+# Built on amd64 in CI and pushed to GHCR; the `full` job runs IN this image and
+# only builds ROSS + CODES, so the slow dependency compiles happen once here
+# instead of on every PR.
+#
+# Base: ubuntu 22.04 (jammy) — it ships python2 (needed by conceptual/UNION, a
+# later stage) AND cmake 3.22 (>= CODES's 3.17 minimum). noble/24.04 drops
+# python2.
+#
+# Built up one dependency at a time (each its own cached layer):
+#   - MPICH + build toolchain + argobots + SWM
+#   - python2 + conceptual + UNION + ZeroMQ (the director-client path)
+#   - SST-DUMPI + LibTorch (CPU)
+# Torch and DUMPI are build-only checks: no trace data / no model ships, so the
+# `full` job just verifies CODES compiles + links with USE_DUMPI / USE_TORCH on.
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Optional apt mirror override. The default arm64 mirror (ports.ubuntu.com) is
+# unreliable for large .debs, which makes LOCAL arm64 builds flaky; pass e.g.
+# --build-arg APT_MIRROR=http://ftp.fau.de/ubuntu-ports to use a faster one.
+# Left empty in CI, where the amd64 image builds from the fast archive.ubuntu.com.
+ARG APT_MIRROR=
+
+# Build toolchain, MPICH, autotools (argobots/SWM build with autotools), and the
+# CODES build deps (cmake/ninja/pkg-config/flex/bison) so the `full` job can
+# build ROSS + CODES inside this image with nothing extra to install.
+RUN if [ -n "$APT_MIRROR" ]; then \
+        sed -i "s|http://ports.ubuntu.com/ubuntu-ports|$APT_MIRROR|g; s|http://archive.ubuntu.com/ubuntu|$APT_MIRROR|g" /etc/apt/sources.list ; \
+    fi \
+    && printf 'Acquire::Retries "8";\nAcquire::http::Timeout "60";\nAcquire::https::Timeout "60";\n' \
+        > /etc/apt/apt.conf.d/80-codes-ci \
+    && apt-get update && apt-get install -y --no-install-recommends \
+        build-essential ca-certificates git curl \
+        autoconf automake libtool m4 \
+        mpich libmpich-dev \
+        cmake ninja-build pkg-config \
+        flex bison \
+    && rm -rf /var/lib/apt/lists/*
+
+# --- argobots: userspace threading, required by SWM in CODES ---
+RUN git clone --depth=1 https://github.com/pmodels/argobots /src/argobots \
+    && cd /src/argobots \
+    && ./autogen.sh \
+    && mkdir build && cd build \
+    && ../configure --disable-shared --prefix=/opt/argobots \
+         CC=mpicc CXX=mpicxx CFLAGS=-g CXXFLAGS=-g \
+    && make -j"$(nproc)" && make install
+
+# SWM's workload models (nekbone, lammps, ...) use header-only Boost
+# (property_tree, foreach, random, tuple). Use libboost-dev, NOT libboost-all-dev:
+# the latter drags in libboost-mpi-dev -> a second MPI (OpenMPI), which then wins
+# find_package(MPI) and whose mpirun refuses to run as root in the container.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libboost-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# --- SWM: online communication workloads ---
+RUN git clone --depth=1 --branch=v1.2 https://github.com/codes-org/swm-workloads /src/swm-workloads \
+    && cd /src/swm-workloads/swm \
+    && ./prepare.sh \
+    && mkdir build && cd build \
+    && ../configure --disable-shared --prefix=/opt/swm \
+         CC=mpicc CXX=mpicxx CFLAGS=-g CXXFLAGS=-g \
+    && make -j"$(nproc)" && make install
+
+# --- python2 + texinfo (build-time only): conceptual/UNION need python2, and
+#     conceptual's autotools build runs makeinfo (texinfo) for its docs. ---
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        python2 texinfo \
+    && rm -rf /var/lib/apt/lists/*
+
+# --- conceptual (ncptl): UNION's workload-description compiler ---
+RUN mkdir -p /src \
+    && curl -L -o /tmp/conceptual.tar.gz \
+        https://sourceforge.net/projects/conceptual/files/conceptual/1.5.1b/conceptual-1.5.1b.tar.gz \
+    && tar -C /src -xzf /tmp/conceptual.tar.gz && rm /tmp/conceptual.tar.gz \
+    && cd /src/conceptual-1.5.1b \
+    && PYTHON=python2 ./configure --prefix=/opt/conceptual LIBS=-lm \
+    && make -j"$(nproc)" && make install
+
+# --- UNION: online workload combiner (needs conceptual + SWM). UNION's build
+#     invokes `python` expecting python2, so shim it onto PATH for the make. ---
+RUN git clone https://github.com/SPEAR-UIC/Union /src/Union \
+    && cd /src/Union && git checkout 99b3df3 \
+    && mkdir -p python-override && ln -sf /usr/bin/python2 python-override/python \
+    && ./prepare.sh \
+    && PYTHON=python2 ./configure --disable-shared \
+         --with-conceptual=/opt/conceptual \
+         --with-conceptual-src=/src/conceptual-1.5.1b \
+         --prefix=/opt/union CC=mpicc CXX=mpicxx \
+    && PATH="$PWD/python-override:$PATH" make -j"$(nproc)" && make install
+
+# --- test-runtime tools: the union workload tests render their config templates
+#     with envsubst (gettext-base). ---
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        gettext-base \
+    && rm -rf /var/lib/apt/lists/*
+
+# --- ZeroMQ + RapidJSON: back the optional director-client / zmqml surrogate
+#     (USE_ZEROMQ). On jammy libzmq3-dev ships zmq.h AND the zmq.hpp C++ binding;
+#     rapidjson-dev is the header-only JSON parser the requester + director-client
+#     use. Both are headers/libs only — libzmqmlrequester.so is built from CODES
+#     source in the build job. ---
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libzmq3-dev rapidjson-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# --- SST-DUMPI: trace-based MPI workloads (USE_DUMPI). Build-only check in CI —
+#     no trace data ships, so the `full` job only verifies CODES compiles + links
+#     against it. CODES finds it via find_library(undumpi) under DUMPI_BUILD_PATH,
+#     so install to /opt/dumpi (libundumpi.a in lib/, headers in include/dumpi/).
+#     Clean the /src tree in the same layer so it doesn't bloat the image. ---
+RUN git clone --depth=1 https://github.com/sstsimulator/sst-dumpi /src/sst-dumpi \
+    && cd /src/sst-dumpi \
+    && ./bootstrap.sh \
+    && mkdir build && cd build \
+    && ../configure --prefix=/opt/dumpi --enable-libdumpi \
+         CC=mpicc CXX=mpicxx CFLAGS=-g CXXFLAGS=-g \
+    && make -j"$(nproc)" && make install \
+    && rm -rf /src/sst-dumpi
+
+# --- LibTorch (CPU): the Torch-JIT packet-latency predictor (USE_TORCH).
+#     Build-only check (no model ships). CODES discovers Torch via
+#     find_package(Torch), which reads Torch_DIR; the build job sets
+#       Torch_DIR=$(python3 -c 'import torch; print(torch.utils.cmake_prefix_path)')/Torch
+#     exactly as CODES-compile-instructions.sh does — i.e. find_package(Torch) is
+#     driven off the *pip* package's cmake_prefix_path, so we install the CPU wheel
+#     rather than the standalone libtorch zip (which has no official aarch64 build).
+#
+#     Pin the install to PyTorch's CPU wheel index. It serves CPU-only wheels for
+#     BOTH amd64 (CI) and aarch64 (local arm64) on cp310 (ubuntu 22.04's python),
+#     so the image is CPU-only on either arch. Critically this avoids PyPI's
+#     DEFAULT torch wheel, which on aarch64 now drags in multi-GB nvidia-cuda-*
+#     deps (the unified Jetson/Grace build) that CODES neither needs nor — per
+#     CODES-compile-instructions.sh's CUDA_HOME guard — accepts for a CPU build. ---
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        python3 python3-pip \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip3 install --no-cache-dir torch --index-url https://download.pytorch.org/whl/cpu


### PR DESCRIPTION
Add the heavy-dependency Docker image (ci/full/Dockerfile) and a workflow (.github/workflows/full-ci-image.yml) that builds it on amd64 and publishes it to ghcr.io/codes-org/codes-ci-full. The image bundles every optional CODES dependency — argobots, SWM, conceptual, UNION, ZeroMQ, RapidJSON, SST-DUMPI, and CPU LibTorch — so the eventual "full" CI job can build ROSS + CODES inside it without recompiling the slow deps on every run.

Lands ahead of the consuming `full` job that will be introduced in #248  so the image is published first: when that job arrives it finds :latest already in GHCR to be sure everything is green in the PR before merging.

The workflow does not run on pull_request and only pushes on master/schedule/dispatch, so it can't move :latest from an untrusted PR.