### PR TITLE
ci: add curl + gnupg to codes-ci-ubuntu24-mpich for codecov-action

### DIFF
--- a/ci/ubuntu24-mpich/Dockerfile
+++ b/ci/ubuntu24-mpich/Dockerfile
@@ -29,16 +29,18 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Toolchain + CODES build deps (cmake/ninja/pkg-config/flex/bison), BOTH compilers
 # the matrix drives (gcc via build-essential + clang), lcov for the coverage job,
-# gettext-base for the surrogate tests' envsubst config templating (present on
-# stock runners but not in the bare base image), and the tools to fetch/build
-# MPICH. Deliberately NO apt mpich -- we build our own below and put it ahead of
-# everything on PATH.
+# gettext-base for the surrogate tests' envsubst config templating, and
+# curl + gnupg for the codecov-action (it downloads its uploader with curl and
+# signature-verifies it with gpg). These are all present on the stock GitHub
+# runners but not in the bare base image, and the tools to fetch/build MPICH.
+# Deliberately NO apt mpich -- we build our own below and put it ahead of PATH.
 RUN apt-get update && apt-get install -y --no-install-recommends \
         build-essential clang \
         cmake ninja-build pkg-config \
         flex bison \
         lcov \
         gettext-base \
+        curl gnupg \
         git ca-certificates wget \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
missing a couple more deps for codecov